### PR TITLE
feat(widget): initial implementation of stateful rendering

### DIFF
--- a/.cliff.toml
+++ b/.cliff.toml
@@ -47,29 +47,29 @@ filter_unconventional = true
 split_commits = false
 # regex for preprocessing the commit messages
 commit_preprocessors = [
-    { pattern = '\((\w+\s)?#([0-9]+)\)', replace = "([#${2}](https://github.com/tui-rs-revival/ratatui/issues/${2}))"},
-    { pattern = '(better safe shared layout cache)', replace = "perf(layout): ${1}" },
-    { pattern = '(Clarify README.md)', replace = "docs(readme): ${1}" },
-    { pattern = '(Update README.md)', replace = "docs(readme): ${1}" },
-    { pattern = '(fix typos|Fix typos)', replace = "fix: ${1}" }
+  { pattern = '\((\w+\s)?#([0-9]+)\)', replace = "([#${2}](https://github.com/tui-rs-revival/ratatui/issues/${2}))" },
+  { pattern = '(better safe shared layout cache)', replace = "perf(layout): ${1}" },
+  { pattern = '(Clarify README.md)', replace = "docs(readme): ${1}" },
+  { pattern = '(Update README.md)', replace = "docs(readme): ${1}" },
+  { pattern = '(fix typos|Fix typos)', replace = "fix: ${1}" },
 ]
 # regex for parsing and grouping commits
 commit_parsers = [
-    { message = "^feat", group = "<!-- 00 -->Features"},
-    { message = "^[fF]ix", group = "<!-- 01 -->Bug Fixes"},
-    { message = "^refactor", group = "<!-- 02 -->Refactor"},
-    { message = "^doc", group = "<!-- 03 -->Documentation"},
-    { message = "^perf", group = "<!-- 04 -->Performance"},
-    { message = "^style", group = "<!-- 05 -->Styling"},
-    { message = "^test", group = "<!-- 06 -->Testing"},
-    { message = "^chore\\(release\\): prepare for", skip = true},
-    { message = "^chore\\(pr\\)", skip = true},
-    { message = "^chore\\(pull\\)", skip = true},
-    { message = "^chore", group = "<!-- 07 -->Miscellaneous Tasks"},
-    { body = ".*security", group = "<!-- 08 -->Security"},
-    { message = "^build", group = "<!-- 09 -->Build"},
-    { message = "^ci", group = "<!-- 10 -->Continuous Integration"},
-    { message = "^revert", group = "<!-- 11 -->Reverted Commits"},
+  { message = "^feat", group = "<!-- 00 -->Features" },
+  { message = "^[fF]ix", group = "<!-- 01 -->Bug Fixes" },
+  { message = "^refactor", group = "<!-- 02 -->Refactor" },
+  { message = "^doc", group = "<!-- 03 -->Documentation" },
+  { message = "^perf", group = "<!-- 04 -->Performance" },
+  { message = "^style", group = "<!-- 05 -->Styling" },
+  { message = "^test", group = "<!-- 06 -->Testing" },
+  { message = "^chore\\(release\\): prepare for", skip = true },
+  { message = "^chore\\(pr\\)", skip = true },
+  { message = "^chore\\(pull\\)", skip = true },
+  { message = "^chore", group = "<!-- 07 -->Miscellaneous Tasks" },
+  { body = ".*security", group = "<!-- 08 -->Security" },
+  { message = "^build", group = "<!-- 09 -->Build" },
+  { message = "^ci", group = "<!-- 10 -->Continuous Integration" },
+  { message = "^revert", group = "<!-- 11 -->Reverted Commits" },
 ]
 # protect breaking changes from being skipped due to matching a skipping commit_parser
 protect_breaking_commits = false

--- a/.deny.toml
+++ b/.deny.toml
@@ -18,13 +18,13 @@
 # dependencies not shared by any other crates, would be ignored, as the target
 # list here is effectively saying which targets you are building for.
 targets = [
-    # The triple can be any string, but only the target triples built in to
-    # rustc (as of 1.40) can be checked against actual config expressions
-    #{ triple = "x86_64-unknown-linux-musl" },
-    # You can also specify which target_features you promise are enabled for a
-    # particular target. target_features are currently not validated against
-    # the actual valid features supported by the target architecture.
-    #{ triple = "wasm32-unknown-unknown", features = ["atomics"] },
+  # The triple can be any string, but only the target triples built in to
+  # rustc (as of 1.40) can be checked against actual config expressions
+  #{ triple = "x86_64-unknown-linux-musl" },
+  # You can also specify which target_features you promise are enabled for a
+  # particular target. target_features are currently not validated against
+  # the actual valid features supported by the target architecture.
+  #{ triple = "wasm32-unknown-unknown", features = ["atomics"] },
 ]
 
 # This section is considered when running `cargo deny check advisories`
@@ -48,7 +48,7 @@ notice = "warn"
 # A list of advisory IDs to ignore. Note that ignored advisories will still
 # output a note when they are encountered.
 ignore = [
-    #"RUSTSEC-0000-0000",
+  #"RUSTSEC-0000-0000",
 ]
 # Threshold for security vulnerabilities, any vulnerability with a CVSS score
 # lower than the range specified will be ignored. Note that ignored advisories
@@ -76,18 +76,18 @@ unlicensed = "deny"
 # See https://spdx.org/licenses/ for list of possible licenses
 # [possible values: any SPDX 3.11 short identifier (+ optional exception)].
 allow = [
-    "MIT",
-    "Apache-2.0",
-    "Unicode-DFS-2016",
-    # "WTFPL",
-    # "AGPL-3.0",
-    #"Apache-2.0 WITH LLVM-exception",
+  "MIT",
+  "Apache-2.0",
+  "Unicode-DFS-2016",
+  # "WTFPL",
+  # "AGPL-3.0",
+  #"Apache-2.0 WITH LLVM-exception",
 ]
 # List of explicitly disallowed licenses
 # See https://spdx.org/licenses/ for list of possible licenses
 # [possible values: any SPDX 3.11 short identifier (+ optional exception)].
 deny = [
-    #"Nokia",
+  #"Nokia",
 ]
 # Lint level for licenses considered copyleft
 copyleft = "allow"
@@ -111,9 +111,9 @@ confidence-threshold = 0.8
 # Allow 1 or more licenses on a per-crate basis, so that particular licenses
 # aren't accepted for every possible crate as with the normal allow list
 exceptions = [
-    # Each entry is the crate and version constraint, and its specific allow
-    # list
-    #{ allow = ["Zlib"], name = "adler32", version = "*" },
+  # Each entry is the crate and version constraint, and its specific allow
+  # list
+  #{ allow = ["Zlib"], name = "adler32", version = "*" },
 ]
 
 # Some crates don't have (easily) machine readable licensing information,
@@ -132,8 +132,8 @@ exceptions = [
 # and the crate will be checked normally, which may produce warnings or errors
 # depending on the rest of your configuration
 #license-files = [
-    # Each entry is a crate relative path, and the (opaque) hash of its contents
-    #{ path = "LICENSE", hash = 0xbd0eed23 }
+# Each entry is a crate relative path, and the (opaque) hash of its contents
+#{ path = "LICENSE", hash = 0xbd0eed23 }
 #]
 
 [licenses.private]
@@ -146,7 +146,7 @@ ignore = false
 # is only published to private registries, and ignore is true, the crate will
 # not have its license(s) checked
 registries = [
-    #"https://sekretz.com/registry
+  #"https://sekretz.com/registry
 ]
 
 # This section is considered when running `cargo deny check bans`.
@@ -165,28 +165,28 @@ wildcards = "allow"
 highlight = "all"
 # List of crates that are allowed. Use with care!
 allow = [
-    #{ name = "ansi_term", version = "=0.11.0" },
+  #{ name = "ansi_term", version = "=0.11.0" },
 ]
 # List of crates to deny
 deny = [
-    # Each entry the name of a crate and a version range. If version is
-    # not specified, all versions will be matched.
-    #{ name = "ansi_term", version = "=0.11.0" },
-    #
-    # Wrapper crates can optionally be specified to allow the crate when it
-    # is a direct dependency of the otherwise banned crate
-    #{ name = "ansi_term", version = "=0.11.0", wrappers = [] },
+  # Each entry the name of a crate and a version range. If version is
+  # not specified, all versions will be matched.
+  #{ name = "ansi_term", version = "=0.11.0" },
+  #
+  # Wrapper crates can optionally be specified to allow the crate when it
+  # is a direct dependency of the otherwise banned crate
+  #{ name = "ansi_term", version = "=0.11.0", wrappers = [] },
 ]
 # Certain crates/versions that will be skipped when doing duplicate detection.
 skip = [
-    #{ name = "ansi_term", version = "=0.11.0" },
+  #{ name = "ansi_term", version = "=0.11.0" },
 ]
 # Similarly to `skip` allows you to skip certain crates during duplicate
 # detection. Unlike skip, it also includes the entire tree of transitive
 # dependencies starting at the specified crate, up to a certain depth, which is
 # by default infinite
 skip-tree = [
-    #{ name = "ansi_term", version = "=0.11.0", depth = 20 },
+  #{ name = "ansi_term", version = "=0.11.0", depth = 20 },
 ]
 
 # This section is considered when running `cargo deny check sources`.

--- a/.rustfmt-toolchain.toml
+++ b/.rustfmt-toolchain.toml
@@ -2,4 +2,4 @@
 [toolchain]
 channel = "nightly-2023-07-01"
 components = ["rustfmt"]
-targets = [ ]
+targets = []

--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,4 +1,4 @@
-edition="2021"
+edition = "2021"
 newline_style = "Unix"
 group_imports = "StdExternalCrate"
 imports_granularity = "Crate"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,12 +32,16 @@ categories = ["command-line-interface", "command-line-utilities"]
 #     "bench",
 # ]
 
+[features]
+unstable = [ "input-handling"]
+input-handling = [ "crossterm", "portable-pty", "bytes" ]
+
 [dependencies]
-bytes = "1.4.0"
+bytes = { version = "1.4.0", optional = true}
 vt100 = "0.15.2"
-portable-pty = "0.8.1"
+portable-pty = { version = "0.8.1", optional = true}
 ratatui = "0.23.0"
-crossterm = "0.27.0"
+crossterm = { version = "0.27.0", optional = true}
 
 [dev-dependencies]
 bytes = "1.4.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,6 +98,11 @@ name = "nested_shell_async"
 doc-scrape-examples = true
 
 [[example]]
+name = "nested_shell_stateful"
+doc-scrape-examples = true
+required-features = ["unstable"]
+
+[[example]]
 name = "smux"
 doc-scrape-examples = true
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,9 +2,16 @@
 name = "tui-term"
 description = "A pseudoterminal widget for ratatui"
 version = "0.1.2"
-authors = ["Alexander Kenji Berthold <aks.kenji@protonmail.com>" ]
+authors = ["Alexander Kenji Berthold <aks.kenji@protonmail.com>"]
 edition = "2021"
-include = ["src/**/*","examples/*","benches/*", "LICENSE", "README.md", "CHANGELOG.md"]
+include = [
+    "src/**/*",
+    "examples/*",
+    "benches/*",
+    "LICENSE",
+    "README.md",
+    "CHANGELOG.md",
+]
 license = "MIT"
 
 readme = "README.md"
@@ -15,13 +22,7 @@ autoexamples = true
 rust-version = "1.66.0"
 
 
-keywords = [
-    "tui",
-    "terminal",
-    "ratatui",
-    "tty",
-    "multiplexer",
-]
+keywords = ["tui", "terminal", "ratatui", "tty", "multiplexer"]
 
 categories = ["command-line-interface", "command-line-utilities"]
 
@@ -36,6 +37,7 @@ bytes = "1.4.0"
 portable-pty = "0.8.1"
 ratatui = "0.22.0"
 vt100 = "0.15.2"
+crossterm = "0.27.0"
 
 [dev-dependencies]
 bytes = "1.4.0"
@@ -68,7 +70,6 @@ harness = false
 [[bench]]
 name = "iai"
 harness = false
-
 
 
 [[example]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,14 +34,15 @@ categories = ["command-line-interface", "command-line-utilities"]
 
 [features]
 unstable = [ "input-handling"]
-input-handling = [ "crossterm", "portable-pty", "bytes" ]
+input-handling = [ "crossterm", "portable-pty", "bytes", "tracing" ]
 
 [dependencies]
-bytes = { version = "1.4.0", optional = true}
 vt100 = "0.15.2"
-portable-pty = { version = "0.8.1", optional = true}
 ratatui = "0.23.0"
+bytes = { version = "1.4.0", optional = true}
 crossterm = { version = "0.27.0", optional = true}
+portable-pty = { version = "0.8.1", optional = true}
+tracing = {version = "0.1.37", optional = true}
 
 [dev-dependencies]
 bytes = "1.4.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,12 +5,12 @@ version = "0.1.4"
 authors = ["Alexander Kenji Berthold <aks.kenji@protonmail.com>"]
 edition = "2021"
 include = [
-    "src/**/*",
-    "examples/*",
-    "benches/*",
-    "LICENSE",
-    "README.md",
-    "CHANGELOG.md",
+  "src/**/*",
+  "examples/*",
+  "benches/*",
+  "LICENSE",
+  "README.md",
+  "CHANGELOG.md",
 ]
 license = "MIT"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,8 @@ categories = ["command-line-interface", "command-line-utilities"]
 # ]
 
 [dependencies]
+bytes = "1.4.0"
+portable-pty = "0.8.1"
 ratatui = "0.22.0"
 vt100 = "0.15.2"
 

--- a/examples/nested_shell.rs
+++ b/examples/nested_shell.rs
@@ -45,7 +45,7 @@ fn main() -> std::io::Result<()> {
     cmd.cwd(cwd);
 
     let size = Size {
-        rows: terminal.size()?.height,
+        rows: terminal.size()?.height - 6,
         cols: terminal.size()?.width,
     };
 

--- a/examples/nested_shell_stateful.rs
+++ b/examples/nested_shell_stateful.rs
@@ -1,0 +1,149 @@
+#![allow(unused_variables)]
+
+use std::{io, sync::mpsc::Sender, time::Duration};
+
+use bytes::Bytes;
+use crossterm::{
+    event::{self, DisableMouseCapture, Event, KeyCode, KeyEventKind},
+    execute,
+    style::ResetColor,
+    terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
+};
+use portable_pty::CommandBuilder;
+use ratatui::{
+    backend::Backend,
+    layout::Alignment,
+    style::{Modifier, Style},
+    widgets::{Block, Borders, Paragraph},
+    Frame,
+};
+use ratatui::{backend::CrosstermBackend, Terminal};
+use tui_term::widget::{PseudoTerminal, PseudoTerminalState};
+
+fn main() -> std::io::Result<()> {
+    let mut stdout = io::stdout();
+    execute!(stdout, ResetColor)?;
+    enable_raw_mode()?;
+    let mut stdout = io::stdout();
+    execute!(stdout, EnterAlternateScreen)?;
+    let backend = CrosstermBackend::new(stdout);
+    let mut terminal = Terminal::new(backend)?;
+
+    let cwd = std::env::current_dir().unwrap();
+    let shell = std::env::var("SHELL").unwrap();
+    let mut command = CommandBuilder::new(shell);
+    command.cwd(cwd);
+
+    let terminal_state = PseudoTerminalState::default();
+
+    let child_process_thread = terminal_state.spawn_child_process_thread(command);
+    let parser_thread = terminal_state.spawn_parser_thread();
+    let (input_sender, input_thread) = terminal_state.spawn_input_thread();
+
+    run(&mut terminal, terminal_state, input_sender)?;
+
+    // restore terminal
+    disable_raw_mode()?;
+    execute!(
+        terminal.backend_mut(),
+        LeaveAlternateScreen,
+        DisableMouseCapture
+    )?;
+    terminal.show_cursor()?;
+    Ok(())
+}
+
+fn run<B: Backend>(
+    terminal: &mut Terminal<B>,
+    mut state: PseudoTerminalState,
+    sender: Sender<Bytes>,
+) -> io::Result<()> {
+    loop {
+        terminal.draw(|f| ui(f, &mut state))?;
+
+        // Event read is blocking
+        if event::poll(Duration::from_millis(10))? {
+            // It's guaranteed that the `read()` won't block when the `poll()`
+            // function returns `true`
+            match event::read()? {
+                Event::Key(key) => {
+                    if key.kind == KeyEventKind::Press {
+                        match key.code {
+                            KeyCode::Char('q') => return Ok(()),
+                            KeyCode::Char(input) => sender
+                                .send(Bytes::from(input.to_string().into_bytes()))
+                                .unwrap(),
+                            KeyCode::Backspace => {
+                                sender.send(Bytes::from(vec![8])).unwrap();
+                            }
+                            KeyCode::Enter => sender.send(Bytes::from(vec![b'\n'])).unwrap(),
+                            KeyCode::Left => sender.send(Bytes::from(vec![27, 91, 68])).unwrap(),
+                            KeyCode::Right => sender.send(Bytes::from(vec![27, 91, 67])).unwrap(),
+                            KeyCode::Up => sender.send(Bytes::from(vec![27, 91, 65])).unwrap(),
+                            KeyCode::Down => sender.send(Bytes::from(vec![27, 91, 66])).unwrap(),
+                            KeyCode::Home => sender.send(Bytes::from(vec![27, 91, 72])).unwrap(),
+                            KeyCode::End => sender.send(Bytes::from(vec![27, 91, 70])).unwrap(),
+                            KeyCode::PageUp => {
+                                sender.send(Bytes::from(vec![27, 91, 53, 126])).unwrap()
+                            }
+                            KeyCode::PageDown => {
+                                sender.send(Bytes::from(vec![27, 91, 54, 126])).unwrap()
+                            }
+                            KeyCode::Tab => sender.send(Bytes::from(vec![9])).unwrap(),
+                            KeyCode::BackTab => sender.send(Bytes::from(vec![27, 91, 90])).unwrap(),
+                            KeyCode::Delete => {
+                                sender.send(Bytes::from(vec![27, 91, 51, 126])).unwrap()
+                            }
+                            KeyCode::Insert => {
+                                sender.send(Bytes::from(vec![27, 91, 50, 126])).unwrap()
+                            }
+                            KeyCode::F(_) => todo!(),
+                            KeyCode::Null => todo!(),
+                            KeyCode::Esc => todo!(),
+                            KeyCode::CapsLock => todo!(),
+                            KeyCode::ScrollLock => todo!(),
+                            KeyCode::NumLock => todo!(),
+                            KeyCode::PrintScreen => todo!(),
+                            KeyCode::Pause => todo!(),
+                            KeyCode::Menu => todo!(),
+                            KeyCode::KeypadBegin => todo!(),
+                            KeyCode::Media(_) => todo!(),
+                            KeyCode::Modifier(_) => todo!(),
+                        }
+                    }
+                }
+                Event::FocusGained => {}
+                Event::FocusLost => {}
+                Event::Mouse(_) => {}
+                Event::Paste(_) => todo!(),
+                Event::Resize(rows, cols) => {
+                    state.parser.write().unwrap().set_size(rows, cols);
+                }
+            }
+        }
+    }
+}
+
+fn ui<B: Backend>(f: &mut Frame<B>, state: &mut PseudoTerminalState) {
+    let chunks = ratatui::layout::Layout::default()
+        .direction(ratatui::layout::Direction::Vertical)
+        .margin(1)
+        .constraints(
+            [
+                ratatui::layout::Constraint::Percentage(100),
+                ratatui::layout::Constraint::Min(1),
+            ]
+            .as_ref(),
+        )
+        .split(f.size());
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .style(Style::default().add_modifier(Modifier::BOLD));
+    let pseudo_term = PseudoTerminal::default().block(block);
+    f.render_stateful_widget(pseudo_term, chunks[0], state);
+    let explanation = "Press q to exit".to_string();
+    let explanation = Paragraph::new(explanation)
+        .style(Style::default().add_modifier(Modifier::BOLD | Modifier::REVERSED))
+        .alignment(Alignment::Center);
+    f.render_widget(explanation, chunks[1]);
+}

--- a/examples/nested_shell_stateful.rs
+++ b/examples/nested_shell_stateful.rs
@@ -39,9 +39,7 @@ fn main() -> std::io::Result<()> {
     let initial_size = terminal.size()?;
     let terminal_state = PseudoTerminalState::new(initial_size);
 
-    let child_process_thread = terminal_state.spawn_child_process_thread(command);
-    let parser_thread = terminal_state.spawn_parser_thread();
-    let (input_sender, input_thread) = terminal_state.spawn_input_thread();
+    let input_sender = terminal_state.spawn(command);
 
     run(&mut terminal, terminal_state, input_sender)?;
 

--- a/src/widget.rs
+++ b/src/widget.rs
@@ -301,6 +301,14 @@ impl PseudoTerminalState {
         }
     }
 
+    /// Spawns needed input handling threads
+    pub fn spawn(&self, command: CommandBuilder) -> Sender<Bytes> {
+        let _child_process_thread = self.spawn_child_process_thread(command);
+        let _parser_thread = self.spawn_parser_thread();
+        let (input_sender, _input_thread) = self.spawn_input_thread();
+        input_sender
+    }
+
     /// Updates the area of the PTY and the parser on a frame update
     pub fn set_area(&mut self, new_area: Rect) {
         let (rows, cols) = (new_area.height, new_area.width);


### PR DESCRIPTION
Opened this branch, because I don't have permissions to push to #82

- [ ] fix stateful widget example
- [x] simplify spawn function
- [x] gate input handling behind unstable feature flag
- [ ] implement an async version
- [ ] implement viewport #14
- [ ] benchmark stateful version
- [ ] add tests for input handling, with different terminal variants
- [ ] write documentation
- [ ] add stateful sync/async examples to test builds
- [ ] optionally? add tracing crate for input handling events, to make it less of a black box
- [ ] carry reference to the child process e.g. a child killer
- [ ] (optional) buffered event handling
- [ ] add a timeout to the parser thread (when it gets sizes of 0).