### PR TITLE
chore(doc): fix typo

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -5,7 +5,7 @@ In this folder you find examples for using `tui-term`.
 To run the `simple_ls_rw` example:
 
 ```
-cargo run --example simple_rw
+cargo run --example simple_ls_chan
 ```
 
 ** Note: The examples provided here are simplified and may omit proper error handling and edge cases for brevity and clarity. They are intended to demonstrate specific features and concepts related to `tui-term`. **


### PR DESCRIPTION
Thank you for maintaining nice library! :)

It seems like `simple_rw` does not exist for now, so changed to `simple_ls_chan`.