### PR TITLE
chore(doc): fix typo

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -8,7 +8,8 @@ To run the `simple_ls_rw` example:
 cargo run --example simple_ls_rw
 ```
 
-** Note: The examples provided here are simplified and may omit proper error handling and edge cases for brevity and clarity. They are intended to demonstrate specific features and concepts related to `tui-term`. **
+> **Note** 
+> The examples provided here are simplified and may omit proper error handling and edge cases for brevity and clarity. They are intended to demonstrate specific features and concepts related to `tui-term`.
 
 ## `simple_ls_chan`
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -5,7 +5,7 @@ In this folder you find examples for using `tui-term`.
 To run the `simple_ls_rw` example:
 
 ```
-cargo run --example simple_ls_chan
+cargo run --example simple_ls_rw
 ```
 
 ** Note: The examples provided here are simplified and may omit proper error handling and edge cases for brevity and clarity. They are intended to demonstrate specific features and concepts related to `tui-term`. **


### PR DESCRIPTION
## About 9e24a15d307f0705ffbb2ef4cd04632d192809b2

I'm sorry that there is a mistake in my PR. (https://github.com/a-kenji/tui-term/pull/108)

Since it said ``To run the `simple_ls_rw` example:``, I should have modified it like `cargo run --example simple_ls_rw`.

## About c980bc705a3e3c6572ce1158571bcf0b292077b3
Also I fixed the note following because it seems like the style of this part(`** Note: The example...`) is not rendered.

I adopted this style,

> **Note** 
> The examples provided here are simplified and may omit proper error handling and edge cases for brevity and clarity. They are intended to demonstrate specific features and concepts related to `tui-term`.

but if you want, it can be like this.

> [!NOTE]  
> The examples provided here are simplified and may omit proper error handling and edge cases for brevity and clarity. They are intended to demonstrate specific features and concepts related to `tui-term`.
