### PR TITLE
chore(release): `v0.1.6`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.5] - 2023-12-18
+
+Compatible with `ratatui`: `v0.25.0`.
+
+### Miscellaneous Tasks
+
+- *(deps)* Bump ratatui from `0.24.0` to `0.25.0` [**breaking**]
+- *(doc)* Fix note style
+- *(doc)* Fix typo
+
+### Bench
+
+- Init divan
+
+### Examples
+
+-  Improve cross platform support
+
 ## [0.1.5] - 2023-10-25
 
 Compatible with `ratatui`: `v0.24.0`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1187,7 +1187,7 @@ dependencies = [
 
 [[package]]
 name = "tui-term"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "bytes",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tui-term"
 description = "A pseudoterminal widget for ratatui"
-version = "0.1.5"
+version = "0.1.6"
 authors = ["Alexander Kenji Berthold <aks.kenji@protonmail.com>"]
 edition = "2021"
 include = [

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ To use `tui-term`, simply add it as a dependency in your Cargo.toml file:
 
 ```
 [dependencies]
-tui-term = "0.1.0"
+tui-term = "0.1.6"
 ```
 or use `cargo add`:
 ```


### PR DESCRIPTION
This release is compatible with the currently released ratatui: `v0.25.0`.