### PR TITLE
chore: specify required feature for controller example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,6 +99,10 @@ name = "nested_shell_async"
 doc-scrape-examples = true
 
 [[example]]
+name = "simple_ls_controller"
+required-features = ["unstable"]
+
+[[example]]
 name = "smux"
 doc-scrape-examples = true
 


### PR DESCRIPTION
Minor nicety so `cargo` won't attempt to build the controller example if the `unstable` feature isn't enabled.