### PR TITLE
Looser coupling with vt100

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,11 +33,12 @@ categories = ["command-line-interface", "command-line-utilities"]
 # ]
 
 [features]
+default = ["vt100"]
 unstable = ["dep:portable-pty"]
 
 [dependencies]
 ratatui = "0.26.1"
-vt100 = "0.15.2"
+vt100 = { version = "0.15.2", optional = true }
 portable-pty = { version = "0.8.1", optional = true }
 
 [dev-dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,6 +49,7 @@
 //!   sequences, but future versions may introduce support for alternative backends.
 
 mod state;
+#[cfg(feature = "vt100")]
 mod vt100_imp;
 pub mod widget;
 
@@ -56,4 +57,5 @@ pub mod widget;
 pub mod controller;
 
 /// Reexport of the vt100 crate to ensure correct version compatibility
+#[cfg(feature = "vt100")]
 pub use vt100;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,7 +27,7 @@
 //! use vt100::Parser;
 //!
 //! let mut parser = vt100::Parser::new(24, 80, 0);
-//! let pseudo_term = PseudoTerminal::new(&parser.screen())
+//! let pseudo_term = PseudoTerminal::new(parser.screen())
 //!     .block(Block::default().title("Terminal").borders(Borders::ALL))
 //!     .style(
 //!         Style::default()
@@ -49,6 +49,7 @@
 //!   sequences, but future versions may introduce support for alternative backends.
 
 mod state;
+mod vt100_imp;
 pub mod widget;
 
 #[cfg(feature = "unstable")]

--- a/src/state.rs
+++ b/src/state.rs
@@ -30,29 +30,8 @@ pub fn handle(term: &PseudoTerminal, area: Rect, buf: &mut Buffer) {
 
             if let Some(screen_cell) = screen.cell(row, col) {
                 if screen_cell.has_contents() {
-                    let fg = screen_cell.fgcolor();
-                    let bg = screen_cell.bgcolor();
-
                     let cell = buf.get_mut(buf_col, buf_row);
-                    cell.set_symbol(&screen_cell.contents());
-                    let fg: Color = fg.into();
-                    let bg: Color = bg.into();
-                    let mut style = Style::reset();
-                    if screen_cell.bold() {
-                        style = style.add_modifier(Modifier::BOLD);
-                    }
-                    if screen_cell.italic() {
-                        style = style.add_modifier(Modifier::ITALIC);
-                    }
-                    if screen_cell.underline() {
-                        style = style.add_modifier(Modifier::UNDERLINED);
-                    }
-                    if screen_cell.inverse() {
-                        style = style.add_modifier(Modifier::REVERSED);
-                    }
-                    cell.set_style(style);
-                    cell.set_fg(fg.into());
-                    cell.set_bg(bg.into());
+                    fill_buf_cell(screen_cell, cell);
                 }
             }
         }
@@ -75,6 +54,31 @@ pub fn handle(term: &PseudoTerminal, area: Rect, buf: &mut Buffer) {
             }
         }
     }
+}
+
+fn fill_buf_cell(screen_cell: &vt100::Cell, buf_cell: &mut ratatui::buffer::Cell) {
+    let fg = screen_cell.fgcolor();
+    let bg = screen_cell.bgcolor();
+
+    buf_cell.set_symbol(&screen_cell.contents());
+    let fg: Color = fg.into();
+    let bg: Color = bg.into();
+    let mut style = Style::reset();
+    if screen_cell.bold() {
+        style = style.add_modifier(Modifier::BOLD);
+    }
+    if screen_cell.italic() {
+        style = style.add_modifier(Modifier::ITALIC);
+    }
+    if screen_cell.underline() {
+        style = style.add_modifier(Modifier::UNDERLINED);
+    }
+    if screen_cell.inverse() {
+        style = style.add_modifier(Modifier::REVERSED);
+    }
+    buf_cell.set_style(style);
+    buf_cell.set_fg(fg.into());
+    buf_cell.set_bg(bg.into());
 }
 
 /// Represents a foreground or background color for cells.

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,14 +1,10 @@
-use ratatui::{
-    buffer::Buffer,
-    layout::Rect,
-    style::{Modifier, Style},
-};
+use ratatui::{buffer::Buffer, layout::Rect};
 
-use crate::widget::PseudoTerminal;
+use crate::widget::{Cell, PseudoTerminal, Screen};
 
 /// Draw the [`Screen`] to the [`Buffer`],
 /// area is the designated area that the consumer provides
-pub fn handle(term: &PseudoTerminal, area: Rect, buf: &mut Buffer) {
+pub fn handle<S: Screen>(term: &PseudoTerminal<S>, area: Rect, buf: &mut Buffer) {
     let cols = area.width;
     let rows = area.height;
     let col_start = area.x;
@@ -31,7 +27,7 @@ pub fn handle(term: &PseudoTerminal, area: Rect, buf: &mut Buffer) {
             if let Some(screen_cell) = screen.cell(row, col) {
                 if screen_cell.has_contents() {
                     let cell = buf.get_mut(buf_col, buf_row);
-                    fill_buf_cell(screen_cell, cell);
+                    screen_cell.apply(cell);
                 }
             }
         }
@@ -52,122 +48,6 @@ pub fn handle(term: &PseudoTerminal, area: Rect, buf: &mut Buffer) {
                     c_cell.set_style(style);
                 }
             }
-        }
-    }
-}
-
-fn fill_buf_cell(screen_cell: &vt100::Cell, buf_cell: &mut ratatui::buffer::Cell) {
-    let fg = screen_cell.fgcolor();
-    let bg = screen_cell.bgcolor();
-
-    buf_cell.set_symbol(&screen_cell.contents());
-    let fg: Color = fg.into();
-    let bg: Color = bg.into();
-    let mut style = Style::reset();
-    if screen_cell.bold() {
-        style = style.add_modifier(Modifier::BOLD);
-    }
-    if screen_cell.italic() {
-        style = style.add_modifier(Modifier::ITALIC);
-    }
-    if screen_cell.underline() {
-        style = style.add_modifier(Modifier::UNDERLINED);
-    }
-    if screen_cell.inverse() {
-        style = style.add_modifier(Modifier::REVERSED);
-    }
-    buf_cell.set_style(style);
-    buf_cell.set_fg(fg.into());
-    buf_cell.set_bg(bg.into());
-}
-
-/// Represents a foreground or background color for cells.
-/// Intermediate translation layer between
-/// [`vt100::Screen`] and [`ratatui::style::Color`]
-#[allow(dead_code)]
-enum Color {
-    Reset,
-    Black,
-    Red,
-    Green,
-    Yellow,
-    Blue,
-    Magenta,
-    Cyan,
-    Gray,
-    DarkGray,
-    LightRed,
-    LightGreen,
-    LightYellow,
-    LightBlue,
-    LightMagenta,
-    LightCyan,
-    White,
-    Rgb(u8, u8, u8),
-    Indexed(u8),
-}
-
-impl From<vt100::Color> for Color {
-    #[inline]
-    fn from(value: vt100::Color) -> Self {
-        match value {
-            vt100::Color::Default => Self::Reset,
-            vt100::Color::Idx(i) => Self::Indexed(i),
-            vt100::Color::Rgb(r, g, b) => Self::Rgb(r, g, b),
-        }
-    }
-}
-
-impl From<Color> for vt100::Color {
-    #[inline]
-    fn from(value: Color) -> Self {
-        match value {
-            Color::Reset => Self::Default,
-            Color::Black => Self::Idx(0),
-            Color::Red => Self::Idx(1),
-            Color::Green => Self::Idx(2),
-            Color::Yellow => Self::Idx(3),
-            Color::Blue => Self::Idx(4),
-            Color::Magenta => Self::Idx(5),
-            Color::Cyan => Self::Idx(6),
-            Color::Gray => Self::Idx(7),
-            Color::DarkGray => Self::Idx(8),
-            Color::LightRed => Self::Idx(9),
-            Color::LightGreen => Self::Idx(10),
-            Color::LightYellow => Self::Idx(11),
-            Color::LightBlue => Self::Idx(12),
-            Color::LightMagenta => Self::Idx(13),
-            Color::LightCyan => Self::Idx(14),
-            Color::White => Self::Idx(15),
-            Color::Rgb(r, g, b) => Self::Rgb(r, g, b),
-            Color::Indexed(i) => Self::Idx(i),
-        }
-    }
-}
-
-impl From<Color> for ratatui::style::Color {
-    #[inline]
-    fn from(value: Color) -> Self {
-        match value {
-            Color::Reset => Self::Reset,
-            Color::Black => Self::Black,
-            Color::Red => Self::Red,
-            Color::Green => Self::Green,
-            Color::Yellow => Self::Yellow,
-            Color::Blue => Self::Blue,
-            Color::Magenta => Self::Magenta,
-            Color::Cyan => Self::Cyan,
-            Color::Gray => Self::Gray,
-            Color::DarkGray => Self::DarkGray,
-            Color::LightRed => Self::LightRed,
-            Color::LightGreen => Self::LightGreen,
-            Color::LightYellow => Self::LightYellow,
-            Color::LightBlue => Self::LightBlue,
-            Color::LightMagenta => Self::LightMagenta,
-            Color::LightCyan => Self::LightCyan,
-            Color::White => Self::White,
-            Color::Rgb(r, g, b) => Self::Rgb(r, g, b),
-            Color::Indexed(i) => Self::Indexed(i),
         }
     }
 }

--- a/src/vt100_imp.rs
+++ b/src/vt100_imp.rs
@@ -1,0 +1,151 @@
+use ratatui::style::{Modifier, Style};
+
+use crate::widget::{Cell, Screen};
+
+impl Screen for vt100::Screen {
+    type C = vt100::Cell;
+
+    #[inline]
+    fn cell(&self, row: u16, col: u16) -> Option<&Self::C> {
+        self.cell(row, col)
+    }
+
+    #[inline]
+    fn hide_cursor(&self) -> bool {
+        self.hide_cursor()
+    }
+
+    #[inline]
+    fn cursor_position(&self) -> (u16, u16) {
+        self.cursor_position()
+    }
+}
+
+impl Cell for vt100::Cell {
+    #[inline]
+    fn has_contents(&self) -> bool {
+        self.has_contents()
+    }
+
+    #[inline]
+    fn apply(&self, cell: &mut ratatui::buffer::Cell) {
+        fill_buf_cell(self, cell)
+    }
+}
+
+#[inline]
+fn fill_buf_cell(screen_cell: &vt100::Cell, buf_cell: &mut ratatui::buffer::Cell) {
+    let fg = screen_cell.fgcolor();
+    let bg = screen_cell.bgcolor();
+
+    buf_cell.set_symbol(&screen_cell.contents());
+    let fg: Color = fg.into();
+    let bg: Color = bg.into();
+    let mut style = Style::reset();
+    if screen_cell.bold() {
+        style = style.add_modifier(Modifier::BOLD);
+    }
+    if screen_cell.italic() {
+        style = style.add_modifier(Modifier::ITALIC);
+    }
+    if screen_cell.underline() {
+        style = style.add_modifier(Modifier::UNDERLINED);
+    }
+    if screen_cell.inverse() {
+        style = style.add_modifier(Modifier::REVERSED);
+    }
+    buf_cell.set_style(style);
+    buf_cell.set_fg(fg.into());
+    buf_cell.set_bg(bg.into());
+}
+
+/// Represents a foreground or background color for cells.
+/// Intermediate translation layer between
+/// [`vt100::Screen`] and [`ratatui::style::Color`]
+#[allow(dead_code)]
+enum Color {
+    Reset,
+    Black,
+    Red,
+    Green,
+    Yellow,
+    Blue,
+    Magenta,
+    Cyan,
+    Gray,
+    DarkGray,
+    LightRed,
+    LightGreen,
+    LightYellow,
+    LightBlue,
+    LightMagenta,
+    LightCyan,
+    White,
+    Rgb(u8, u8, u8),
+    Indexed(u8),
+}
+
+impl From<vt100::Color> for Color {
+    #[inline]
+    fn from(value: vt100::Color) -> Self {
+        match value {
+            vt100::Color::Default => Self::Reset,
+            vt100::Color::Idx(i) => Self::Indexed(i),
+            vt100::Color::Rgb(r, g, b) => Self::Rgb(r, g, b),
+        }
+    }
+}
+
+impl From<Color> for vt100::Color {
+    #[inline]
+    fn from(value: Color) -> Self {
+        match value {
+            Color::Reset => Self::Default,
+            Color::Black => Self::Idx(0),
+            Color::Red => Self::Idx(1),
+            Color::Green => Self::Idx(2),
+            Color::Yellow => Self::Idx(3),
+            Color::Blue => Self::Idx(4),
+            Color::Magenta => Self::Idx(5),
+            Color::Cyan => Self::Idx(6),
+            Color::Gray => Self::Idx(7),
+            Color::DarkGray => Self::Idx(8),
+            Color::LightRed => Self::Idx(9),
+            Color::LightGreen => Self::Idx(10),
+            Color::LightYellow => Self::Idx(11),
+            Color::LightBlue => Self::Idx(12),
+            Color::LightMagenta => Self::Idx(13),
+            Color::LightCyan => Self::Idx(14),
+            Color::White => Self::Idx(15),
+            Color::Rgb(r, g, b) => Self::Rgb(r, g, b),
+            Color::Indexed(i) => Self::Idx(i),
+        }
+    }
+}
+
+impl From<Color> for ratatui::style::Color {
+    #[inline]
+    fn from(value: Color) -> Self {
+        match value {
+            Color::Reset => Self::Reset,
+            Color::Black => Self::Black,
+            Color::Red => Self::Red,
+            Color::Green => Self::Green,
+            Color::Yellow => Self::Yellow,
+            Color::Blue => Self::Blue,
+            Color::Magenta => Self::Magenta,
+            Color::Cyan => Self::Cyan,
+            Color::Gray => Self::Gray,
+            Color::DarkGray => Self::DarkGray,
+            Color::LightRed => Self::LightRed,
+            Color::LightGreen => Self::LightGreen,
+            Color::LightYellow => Self::LightYellow,
+            Color::LightBlue => Self::LightBlue,
+            Color::LightMagenta => Self::LightMagenta,
+            Color::LightCyan => Self::LightCyan,
+            Color::White => Self::White,
+            Color::Rgb(r, g, b) => Self::Rgb(r, g, b),
+            Color::Indexed(i) => Self::Indexed(i),
+        }
+    }
+}

--- a/src/widget.rs
+++ b/src/widget.rs
@@ -286,7 +286,7 @@ impl<S: Screen> Widget for PseudoTerminal<'_, S> {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "vt100"))]
 mod tests {
     use ratatui::{backend::TestBackend, widgets::Borders, Terminal};
 

--- a/src/widget.rs
+++ b/src/widget.rs
@@ -4,9 +4,21 @@ use ratatui::{
     style::{Color, Modifier, Style},
     widgets::{Block, Clear, Widget},
 };
-use vt100::Screen;
 
 use crate::state;
+
+pub trait Screen {
+    type C: Cell;
+
+    fn cell(&self, row: u16, col: u16) -> Option<&Self::C>;
+    fn hide_cursor(&self) -> bool;
+    fn cursor_position(&self) -> (u16, u16);
+}
+
+pub trait Cell {
+    fn has_contents(&self) -> bool;
+    fn apply(&self, cell: &mut ratatui::buffer::Cell);
+}
 
 /// A widget representing a pseudo-terminal screen.
 ///
@@ -30,7 +42,7 @@ use crate::state;
 /// use vt100::Parser;
 ///
 /// let mut parser = vt100::Parser::new(24, 80, 0);
-/// let pseudo_term = PseudoTerminal::new(&parser.screen())
+/// let pseudo_term = PseudoTerminal::new(parser.screen())
 ///     .block(Block::default().title("Terminal").borders(Borders::ALL))
 ///     .style(
 ///         Style::default()
@@ -40,8 +52,8 @@ use crate::state;
 ///     );
 /// ```
 #[non_exhaustive]
-pub struct PseudoTerminal<'a> {
-    screen: &'a Screen,
+pub struct PseudoTerminal<'a, S> {
+    screen: &'a S,
     pub(crate) block: Option<Block<'a>>,
     style: Option<Style>,
     pub(crate) cursor: Cursor,
@@ -154,7 +166,7 @@ impl Default for Cursor {
     }
 }
 
-impl<'a> PseudoTerminal<'a> {
+impl<'a, S: Screen> PseudoTerminal<'a, S> {
     /// Creates a new instance of `PseudoTerminal`.
     ///
     /// # Arguments
@@ -168,11 +180,11 @@ impl<'a> PseudoTerminal<'a> {
     /// use vt100::Parser;
     ///
     /// let mut parser = vt100::Parser::new(24, 80, 0);
-    /// let pseudo_term = PseudoTerminal::new(&parser.screen());
+    /// let pseudo_term = PseudoTerminal::new(parser.screen());
     /// ```
     #[inline]
     #[must_use]
-    pub fn new(screen: &'a Screen) -> Self {
+    pub fn new(screen: &'a S) -> Self {
         PseudoTerminal {
             screen,
             block: None,
@@ -196,7 +208,7 @@ impl<'a> PseudoTerminal<'a> {
     ///
     /// let mut parser = vt100::Parser::new(24, 80, 0);
     /// let block = Block::default();
-    /// let pseudo_term = PseudoTerminal::new(&parser.screen()).block(block);
+    /// let pseudo_term = PseudoTerminal::new(parser.screen()).block(block);
     /// ```
     #[inline]
     #[must_use]
@@ -222,7 +234,7 @@ impl<'a> PseudoTerminal<'a> {
     ///
     /// let mut parser = vt100::Parser::new(24, 80, 0);
     /// let cursor = Cursor::default().symbol("|").style(Style::default());
-    /// let pseudo_term = PseudoTerminal::new(&parser.screen()).cursor(cursor);
+    /// let pseudo_term = PseudoTerminal::new(parser.screen()).cursor(cursor);
     /// ```
     #[inline]
     #[must_use]
@@ -245,7 +257,7 @@ impl<'a> PseudoTerminal<'a> {
     ///
     /// let mut parser = vt100::Parser::new(24, 80, 0);
     /// let style = Style::default();
-    /// let pseudo_term = PseudoTerminal::new(&parser.screen()).style(style);
+    /// let pseudo_term = PseudoTerminal::new(parser.screen()).style(style);
     /// ```
     #[inline]
     #[must_use]
@@ -256,12 +268,12 @@ impl<'a> PseudoTerminal<'a> {
 
     #[inline]
     #[must_use]
-    pub const fn screen(&self) -> &Screen {
+    pub const fn screen(&self) -> &S {
         self.screen
     }
 }
 
-impl Widget for PseudoTerminal<'_> {
+impl<S: Screen> Widget for PseudoTerminal<'_, S> {
     #[inline]
     fn render(self, area: Rect, buf: &mut Buffer) {
         Clear.render(area, buf);

--- a/src/widget.rs
+++ b/src/widget.rs
@@ -7,16 +7,29 @@ use ratatui::{
 
 use crate::state;
 
+/// A trait representing a pseudo-terminal screen.
+///
+/// Implementing this trait allows for backends other than `vt100` to be used
+/// with the `PseudoTerminal` widget.
 pub trait Screen {
+    /// The type of cell this screen contains
     type C: Cell;
 
+    /// Returns the cell at the given location if it exists.
     fn cell(&self, row: u16, col: u16) -> Option<&Self::C>;
+    /// Returns whether the terminal should be hidden
     fn hide_cursor(&self) -> bool;
+    /// Returns cursor position of screen.
+    ///
+    /// The return value is expected to be (row, column)
     fn cursor_position(&self) -> (u16, u16);
 }
 
+/// A trait for representing a single cell on a screen.
 pub trait Cell {
+    /// Whether the cell has any contents that could be rendered to the screen.
     fn has_contents(&self) -> bool;
+    /// Apply the contents and styling of this cell to the provided buffer cell.
     fn apply(&self, cell: &mut ratatui::buffer::Cell);
 }
 


### PR DESCRIPTION
Addresses #150 

Adds a generic `Screen` and `Cell` traits that opens the possibility of using `tui-term` with libraries other than `vt100`.

This is a breaking change in a few ways:
 - `PseudoTerminal` now contains a generic.
 - Automatic dereferencing no longer works for the constructor e.g. `PseudoTerminal::new(&parser.screen())` will fail. This could be avoided with a `impl<'a> Screen for &'a vt100::Screen`, but wasn't sure this was desired. Will add it if desired.

Please let me know if there's additional tests that would be beneficial.

Alternatives:
We could try to avoid leaking the underlying `Screen` type by storing a `&dyn Screen`, but that would require reworking the interface to not have [an associated type](https://doc.rust-lang.org/reference/items/traits.html#object-safety).