### PR TITLE
Fix parameter order of crossterm resize event

### DIFF
--- a/examples/nested_shell.rs
+++ b/examples/nested_shell.rs
@@ -178,7 +178,7 @@ fn run<B: Backend>(
                 Event::FocusLost => {}
                 Event::Mouse(_) => {}
                 Event::Paste(_) => todo!(),
-                Event::Resize(rows, cols) => {
+                Event::Resize(cols, rows) => {
                     parser.write().unwrap().set_size(rows, cols);
                 }
             }

--- a/examples/nested_shell_async.rs
+++ b/examples/nested_shell_async.rs
@@ -181,7 +181,7 @@ async fn run<B: Backend>(
                 Event::FocusLost => {}
                 Event::Mouse(_) => {}
                 Event::Paste(_) => todo!(),
-                Event::Resize(rows, cols) => {
+                Event::Resize(cols, rows) => {
                     parser.write().unwrap().set_size(rows, cols);
                 }
             }

--- a/examples/smux.rs
+++ b/examples/smux.rs
@@ -137,7 +137,7 @@ async fn main() -> io::Result<()> {
                         }
                     }
                 },
-                Event::Resize(rows, cols) => {
+                Event::Resize(cols, rows) => {
                     tracing::info!("Resized to: rows: {} cols: {}", rows, cols);
                     for pane in panes.iter_mut() {
                         pane.parser.write().unwrap().set_size(rows, cols);


### PR DESCRIPTION
As documented on https://docs.rs/crossterm/latest/crossterm/event/enum.Event.html, the resize event's parameters are `(columns, rows)`, not `(rows, cols)`.

To make resize really work in the examples, We need to call `resize` on master pty. I might do it in a follow up PR.