### PR TITLE
Use patched version of vt100 -> vt100-ctt

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1258,7 +1258,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "vt100",
+ "vt100-ctt",
 ]
 
 [[package]]
@@ -1314,10 +1314,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
-name = "vt100"
-version = "0.15.2"
+name = "vt100-ctt"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84cd863bf0db7e392ba3bd04994be3473491b31e66340672af5d11943c6274de"
+checksum = "bb16a4afd5cab1ab1efbf1e50ccaaefc2f47e0c12fb1bb14fe1bf9f29b0f5fff"
 dependencies = [
  "itoa",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,10 +30,11 @@ categories = ["command-line-interface", "command-line-utilities"]
 [features]
 default = ["vt100"]
 unstable = ["dep:portable-pty"]
+vt100 = ["vt100-ctt"]
 
 [dependencies]
 ratatui = { version = "0.29.0", default-features = false }
-vt100 = { version = "0.15.2", optional = true }
+vt100-ctt = { version = "0.15.3", optional = true }
 portable-pty = { version = "0.8.1", optional = true }
 
 [dev-dependencies]

--- a/benches/benches.rs
+++ b/benches/benches.rs
@@ -2,116 +2,116 @@ use criterion::{criterion_group, criterion_main, Criterion};
 use once_cell::sync::Lazy;
 use ratatui::{backend::TestBackend, Terminal};
 use tui_term::widget::PseudoTerminal;
-use vt100::Screen;
+use vt100_ctt::Screen;
 
 static SIMPLE_LS_ACTIONS: Lazy<Screen> = Lazy::new(|| {
     let stream = include_bytes!("../test/typescript/simple_ls.typescript");
-    let mut parser = vt100::Parser::new(24, 80, 0);
+    let mut parser = vt100_ctt::Parser::new(24, 80, 0);
     parser.process(stream);
     parser.screen().clone()
 });
 
 static VTTEST_02_01: Lazy<Screen> = Lazy::new(|| {
     let stream = include_bytes!("../test/typescript/vttest_02_01.typescript");
-    let mut parser = vt100::Parser::new(24, 80, 0);
+    let mut parser = vt100_ctt::Parser::new(24, 80, 0);
     parser.process(stream);
     parser.screen().clone()
 });
 
 static VTTEST_02_02: Lazy<Screen> = Lazy::new(|| {
     let stream = include_bytes!("../test/typescript/vttest_02_02.typescript");
-    let mut parser = vt100::Parser::new(24, 80, 0);
+    let mut parser = vt100_ctt::Parser::new(24, 80, 0);
     parser.process(stream);
     parser.screen().clone()
 });
 
 static VTTEST_02_03: Lazy<Screen> = Lazy::new(|| {
     let stream = include_bytes!("../test/typescript/vttest_02_03.typescript");
-    let mut parser = vt100::Parser::new(24, 80, 0);
+    let mut parser = vt100_ctt::Parser::new(24, 80, 0);
     parser.process(stream);
     parser.screen().clone()
 });
 
 static VTTEST_02_04: Lazy<Screen> = Lazy::new(|| {
     let stream = include_bytes!("../test/typescript/vttest_02_04.typescript");
-    let mut parser = vt100::Parser::new(24, 80, 0);
+    let mut parser = vt100_ctt::Parser::new(24, 80, 0);
     parser.process(stream);
     parser.screen().clone()
 });
 
 static VTTEST_02_05: Lazy<Screen> = Lazy::new(|| {
     let stream = include_bytes!("../test/typescript/vttest_02_05.typescript");
-    let mut parser = vt100::Parser::new(24, 80, 0);
+    let mut parser = vt100_ctt::Parser::new(24, 80, 0);
     parser.process(stream);
     parser.screen().clone()
 });
 
 static VTTEST_02_06: Lazy<Screen> = Lazy::new(|| {
     let stream = include_bytes!("../test/typescript/vttest_02_06.typescript");
-    let mut parser = vt100::Parser::new(24, 80, 0);
+    let mut parser = vt100_ctt::Parser::new(24, 80, 0);
     parser.process(stream);
     parser.screen().clone()
 });
 
 static VTTEST_02_07: Lazy<Screen> = Lazy::new(|| {
     let stream = include_bytes!("../test/typescript/vttest_02_07.typescript");
-    let mut parser = vt100::Parser::new(24, 80, 0);
+    let mut parser = vt100_ctt::Parser::new(24, 80, 0);
     parser.process(stream);
     parser.screen().clone()
 });
 
 static VTTEST_02_08: Lazy<Screen> = Lazy::new(|| {
     let stream = include_bytes!("../test/typescript/vttest_02_08.typescript");
-    let mut parser = vt100::Parser::new(24, 80, 0);
+    let mut parser = vt100_ctt::Parser::new(24, 80, 0);
     parser.process(stream);
     parser.screen().clone()
 });
 
 static VTTEST_02_09: Lazy<Screen> = Lazy::new(|| {
     let stream = include_bytes!("../test/typescript/vttest_02_09.typescript");
-    let mut parser = vt100::Parser::new(24, 80, 0);
+    let mut parser = vt100_ctt::Parser::new(24, 80, 0);
     parser.process(stream);
     parser.screen().clone()
 });
 
 static VTTEST_02_10: Lazy<Screen> = Lazy::new(|| {
     let stream = include_bytes!("../test/typescript/vttest_02_10.typescript");
-    let mut parser = vt100::Parser::new(24, 80, 0);
+    let mut parser = vt100_ctt::Parser::new(24, 80, 0);
     parser.process(stream);
     parser.screen().clone()
 });
 
 static VTTEST_02_11: Lazy<Screen> = Lazy::new(|| {
     let stream = include_bytes!("../test/typescript/vttest_02_11.typescript");
-    let mut parser = vt100::Parser::new(24, 80, 0);
+    let mut parser = vt100_ctt::Parser::new(24, 80, 0);
     parser.process(stream);
     parser.screen().clone()
 });
 
 static VTTEST_02_12: Lazy<Screen> = Lazy::new(|| {
     let stream = include_bytes!("../test/typescript/vttest_02_12.typescript");
-    let mut parser = vt100::Parser::new(24, 80, 0);
+    let mut parser = vt100_ctt::Parser::new(24, 80, 0);
     parser.process(stream);
     parser.screen().clone()
 });
 
 static VTTEST_02_13: Lazy<Screen> = Lazy::new(|| {
     let stream = include_bytes!("../test/typescript/vttest_02_13.typescript");
-    let mut parser = vt100::Parser::new(24, 80, 0);
+    let mut parser = vt100_ctt::Parser::new(24, 80, 0);
     parser.process(stream);
     parser.screen().clone()
 });
 
 static VTTEST_02_14: Lazy<Screen> = Lazy::new(|| {
     let stream = include_bytes!("../test/typescript/vttest_02_14.typescript");
-    let mut parser = vt100::Parser::new(24, 80, 0);
+    let mut parser = vt100_ctt::Parser::new(24, 80, 0);
     parser.process(stream);
     parser.screen().clone()
 });
 
 static VTTEST_02_15: Lazy<Screen> = Lazy::new(|| {
     let stream = include_bytes!("../test/typescript/vttest_02_15.typescript");
-    let mut parser = vt100::Parser::new(24, 80, 0);
+    let mut parser = vt100_ctt::Parser::new(24, 80, 0);
     parser.process(stream);
     parser.screen().clone()
 });

--- a/benches/divan.rs
+++ b/benches/divan.rs
@@ -1,7 +1,7 @@
 use once_cell::sync::Lazy;
 use ratatui::{backend::TestBackend, Terminal};
 use tui_term::widget::PseudoTerminal;
-use vt100::Screen;
+use vt100_ctt::Screen;
 
 fn main() {
     divan::main();
@@ -9,112 +9,112 @@ fn main() {
 
 static SIMPLE_LS_ACTIONS: Lazy<Screen> = Lazy::new(|| {
     let stream = include_bytes!("../test/typescript/simple_ls.typescript");
-    let mut parser = vt100::Parser::new(24, 80, 0);
+    let mut parser = vt100_ctt::Parser::new(24, 80, 0);
     parser.process(stream);
     parser.screen().clone()
 });
 
 static VTTEST_02_01: Lazy<Screen> = Lazy::new(|| {
     let stream = include_bytes!("../test/typescript/vttest_02_01.typescript");
-    let mut parser = vt100::Parser::new(24, 80, 0);
+    let mut parser = vt100_ctt::Parser::new(24, 80, 0);
     parser.process(stream);
     parser.screen().clone()
 });
 
 static VTTEST_02_02: Lazy<Screen> = Lazy::new(|| {
     let stream = include_bytes!("../test/typescript/vttest_02_02.typescript");
-    let mut parser = vt100::Parser::new(24, 80, 0);
+    let mut parser = vt100_ctt::Parser::new(24, 80, 0);
     parser.process(stream);
     parser.screen().clone()
 });
 
 static VTTEST_02_03: Lazy<Screen> = Lazy::new(|| {
     let stream = include_bytes!("../test/typescript/vttest_02_03.typescript");
-    let mut parser = vt100::Parser::new(24, 80, 0);
+    let mut parser = vt100_ctt::Parser::new(24, 80, 0);
     parser.process(stream);
     parser.screen().clone()
 });
 
 static VTTEST_02_04: Lazy<Screen> = Lazy::new(|| {
     let stream = include_bytes!("../test/typescript/vttest_02_04.typescript");
-    let mut parser = vt100::Parser::new(24, 80, 0);
+    let mut parser = vt100_ctt::Parser::new(24, 80, 0);
     parser.process(stream);
     parser.screen().clone()
 });
 
 static VTTEST_02_05: Lazy<Screen> = Lazy::new(|| {
     let stream = include_bytes!("../test/typescript/vttest_02_05.typescript");
-    let mut parser = vt100::Parser::new(24, 80, 0);
+    let mut parser = vt100_ctt::Parser::new(24, 80, 0);
     parser.process(stream);
     parser.screen().clone()
 });
 
 static VTTEST_02_06: Lazy<Screen> = Lazy::new(|| {
     let stream = include_bytes!("../test/typescript/vttest_02_06.typescript");
-    let mut parser = vt100::Parser::new(24, 80, 0);
+    let mut parser = vt100_ctt::Parser::new(24, 80, 0);
     parser.process(stream);
     parser.screen().clone()
 });
 
 static VTTEST_02_07: Lazy<Screen> = Lazy::new(|| {
     let stream = include_bytes!("../test/typescript/vttest_02_07.typescript");
-    let mut parser = vt100::Parser::new(24, 80, 0);
+    let mut parser = vt100_ctt::Parser::new(24, 80, 0);
     parser.process(stream);
     parser.screen().clone()
 });
 
 static VTTEST_02_08: Lazy<Screen> = Lazy::new(|| {
     let stream = include_bytes!("../test/typescript/vttest_02_08.typescript");
-    let mut parser = vt100::Parser::new(24, 80, 0);
+    let mut parser = vt100_ctt::Parser::new(24, 80, 0);
     parser.process(stream);
     parser.screen().clone()
 });
 
 static VTTEST_02_09: Lazy<Screen> = Lazy::new(|| {
     let stream = include_bytes!("../test/typescript/vttest_02_09.typescript");
-    let mut parser = vt100::Parser::new(24, 80, 0);
+    let mut parser = vt100_ctt::Parser::new(24, 80, 0);
     parser.process(stream);
     parser.screen().clone()
 });
 
 static VTTEST_02_10: Lazy<Screen> = Lazy::new(|| {
     let stream = include_bytes!("../test/typescript/vttest_02_10.typescript");
-    let mut parser = vt100::Parser::new(24, 80, 0);
+    let mut parser = vt100_ctt::Parser::new(24, 80, 0);
     parser.process(stream);
     parser.screen().clone()
 });
 
 static VTTEST_02_11: Lazy<Screen> = Lazy::new(|| {
     let stream = include_bytes!("../test/typescript/vttest_02_11.typescript");
-    let mut parser = vt100::Parser::new(24, 80, 0);
+    let mut parser = vt100_ctt::Parser::new(24, 80, 0);
     parser.process(stream);
     parser.screen().clone()
 });
 
 static VTTEST_02_12: Lazy<Screen> = Lazy::new(|| {
     let stream = include_bytes!("../test/typescript/vttest_02_12.typescript");
-    let mut parser = vt100::Parser::new(24, 80, 0);
+    let mut parser = vt100_ctt::Parser::new(24, 80, 0);
     parser.process(stream);
     parser.screen().clone()
 });
 
 static VTTEST_02_13: Lazy<Screen> = Lazy::new(|| {
     let stream = include_bytes!("../test/typescript/vttest_02_13.typescript");
-    let mut parser = vt100::Parser::new(24, 80, 0);
+    let mut parser = vt100_ctt::Parser::new(24, 80, 0);
     parser.process(stream);
     parser.screen().clone()
 });
 
 static VTTEST_02_14: Lazy<Screen> = Lazy::new(|| {
     let stream = include_bytes!("../test/typescript/vttest_02_14.typescript");
-    let mut parser = vt100::Parser::new(24, 80, 0);
+    let mut parser = vt100_ctt::Parser::new(24, 80, 0);
     parser.process(stream);
     parser.screen().clone()
 });
 
 static VTTEST_02_15: Lazy<Screen> = Lazy::new(|| {
     let stream = include_bytes!("../test/typescript/vttest_02_15.typescript");
-    let mut parser = vt100::Parser::new(24, 80, 0);
+    let mut parser = vt100_ctt::Parser::new(24, 80, 0);
     parser.process(stream);
     parser.screen().clone()
 });

--- a/benches/iai.rs
+++ b/benches/iai.rs
@@ -1,116 +1,116 @@
 use once_cell::sync::Lazy;
 use ratatui::{backend::TestBackend, Terminal};
 use tui_term::widget::PseudoTerminal;
-use vt100::Screen;
+use vt100_ctt::Screen;
 
 static SIMPLE_LS_ACTIONS: Lazy<Screen> = Lazy::new(|| {
     let stream = include_bytes!("../test/typescript/simple_ls.typescript");
-    let mut parser = vt100::Parser::new(24, 80, 0);
+    let mut parser = vt100_ctt::Parser::new(24, 80, 0);
     parser.process(stream);
     parser.screen().clone()
 });
 
 static VTTEST_02_01: Lazy<Screen> = Lazy::new(|| {
     let stream = include_bytes!("../test/typescript/vttest_02_01.typescript");
-    let mut parser = vt100::Parser::new(24, 80, 0);
+    let mut parser = vt100_ctt::Parser::new(24, 80, 0);
     parser.process(stream);
     parser.screen().clone()
 });
 
 static VTTEST_02_02: Lazy<Screen> = Lazy::new(|| {
     let stream = include_bytes!("../test/typescript/vttest_02_02.typescript");
-    let mut parser = vt100::Parser::new(24, 80, 0);
+    let mut parser = vt100_ctt::Parser::new(24, 80, 0);
     parser.process(stream);
     parser.screen().clone()
 });
 
 static VTTEST_02_03: Lazy<Screen> = Lazy::new(|| {
     let stream = include_bytes!("../test/typescript/vttest_02_03.typescript");
-    let mut parser = vt100::Parser::new(24, 80, 0);
+    let mut parser = vt100_ctt::Parser::new(24, 80, 0);
     parser.process(stream);
     parser.screen().clone()
 });
 
 static VTTEST_02_04: Lazy<Screen> = Lazy::new(|| {
     let stream = include_bytes!("../test/typescript/vttest_02_04.typescript");
-    let mut parser = vt100::Parser::new(24, 80, 0);
+    let mut parser = vt100_ctt::Parser::new(24, 80, 0);
     parser.process(stream);
     parser.screen().clone()
 });
 
 static VTTEST_02_05: Lazy<Screen> = Lazy::new(|| {
     let stream = include_bytes!("../test/typescript/vttest_02_05.typescript");
-    let mut parser = vt100::Parser::new(24, 80, 0);
+    let mut parser = vt100_ctt::Parser::new(24, 80, 0);
     parser.process(stream);
     parser.screen().clone()
 });
 
 static VTTEST_02_06: Lazy<Screen> = Lazy::new(|| {
     let stream = include_bytes!("../test/typescript/vttest_02_06.typescript");
-    let mut parser = vt100::Parser::new(24, 80, 0);
+    let mut parser = vt100_ctt::Parser::new(24, 80, 0);
     parser.process(stream);
     parser.screen().clone()
 });
 
 static VTTEST_02_07: Lazy<Screen> = Lazy::new(|| {
     let stream = include_bytes!("../test/typescript/vttest_02_07.typescript");
-    let mut parser = vt100::Parser::new(24, 80, 0);
+    let mut parser = vt100_ctt::Parser::new(24, 80, 0);
     parser.process(stream);
     parser.screen().clone()
 });
 
 static VTTEST_02_08: Lazy<Screen> = Lazy::new(|| {
     let stream = include_bytes!("../test/typescript/vttest_02_08.typescript");
-    let mut parser = vt100::Parser::new(24, 80, 0);
+    let mut parser = vt100_ctt::Parser::new(24, 80, 0);
     parser.process(stream);
     parser.screen().clone()
 });
 
 static VTTEST_02_09: Lazy<Screen> = Lazy::new(|| {
     let stream = include_bytes!("../test/typescript/vttest_02_09.typescript");
-    let mut parser = vt100::Parser::new(24, 80, 0);
+    let mut parser = vt100_ctt::Parser::new(24, 80, 0);
     parser.process(stream);
     parser.screen().clone()
 });
 
 static VTTEST_02_10: Lazy<Screen> = Lazy::new(|| {
     let stream = include_bytes!("../test/typescript/vttest_02_10.typescript");
-    let mut parser = vt100::Parser::new(24, 80, 0);
+    let mut parser = vt100_ctt::Parser::new(24, 80, 0);
     parser.process(stream);
     parser.screen().clone()
 });
 
 static VTTEST_02_11: Lazy<Screen> = Lazy::new(|| {
     let stream = include_bytes!("../test/typescript/vttest_02_11.typescript");
-    let mut parser = vt100::Parser::new(24, 80, 0);
+    let mut parser = vt100_ctt::Parser::new(24, 80, 0);
     parser.process(stream);
     parser.screen().clone()
 });
 
 static VTTEST_02_12: Lazy<Screen> = Lazy::new(|| {
     let stream = include_bytes!("../test/typescript/vttest_02_12.typescript");
-    let mut parser = vt100::Parser::new(24, 80, 0);
+    let mut parser = vt100_ctt::Parser::new(24, 80, 0);
     parser.process(stream);
     parser.screen().clone()
 });
 
 static VTTEST_02_13: Lazy<Screen> = Lazy::new(|| {
     let stream = include_bytes!("../test/typescript/vttest_02_13.typescript");
-    let mut parser = vt100::Parser::new(24, 80, 0);
+    let mut parser = vt100_ctt::Parser::new(24, 80, 0);
     parser.process(stream);
     parser.screen().clone()
 });
 
 static VTTEST_02_14: Lazy<Screen> = Lazy::new(|| {
     let stream = include_bytes!("../test/typescript/vttest_02_14.typescript");
-    let mut parser = vt100::Parser::new(24, 80, 0);
+    let mut parser = vt100_ctt::Parser::new(24, 80, 0);
     parser.process(stream);
     parser.screen().clone()
 });
 
 static VTTEST_02_15: Lazy<Screen> = Lazy::new(|| {
     let stream = include_bytes!("../test/typescript/vttest_02_15.typescript");
-    let mut parser = vt100::Parser::new(24, 80, 0);
+    let mut parser = vt100_ctt::Parser::new(24, 80, 0);
     parser.process(stream);
     parser.screen().clone()
 });

--- a/examples/long_running.rs
+++ b/examples/long_running.rs
@@ -20,7 +20,7 @@ use ratatui::{
     Frame, Terminal,
 };
 use tui_term::widget::PseudoTerminal;
-use vt100::Screen;
+use vt100_ctt::Screen;
 
 fn main() -> std::io::Result<()> {
     let mut stdout = io::stdout();
@@ -52,7 +52,7 @@ fn main() -> std::io::Result<()> {
     });
 
     let mut reader = pair.master.try_clone_reader().unwrap();
-    let parser = Arc::new(RwLock::new(vt100::Parser::new(24, 80, 0)));
+    let parser = Arc::new(RwLock::new(vt100_ctt::Parser::new(24, 80, 0)));
 
     {
         let parser = parser.clone();
@@ -99,7 +99,7 @@ fn main() -> std::io::Result<()> {
 
 fn run<B: Backend>(
     terminal: &mut Terminal<B>,
-    parser: Arc<RwLock<vt100::Parser>>,
+    parser: Arc<RwLock<vt100_ctt::Parser>>,
 ) -> io::Result<()> {
     loop {
         terminal.draw(|f| ui(f, parser.read().unwrap().screen()))?;

--- a/examples/nested_shell.rs
+++ b/examples/nested_shell.rs
@@ -20,7 +20,7 @@ use ratatui::{
     Frame, Terminal,
 };
 use tui_term::widget::PseudoTerminal;
-use vt100::Screen;
+use vt100_ctt::Screen;
 
 #[derive(Debug)]
 struct Size {
@@ -63,7 +63,7 @@ fn main() -> std::io::Result<()> {
     });
 
     let mut reader = pair.master.try_clone_reader().unwrap();
-    let parser = Arc::new(RwLock::new(vt100::Parser::new(size.rows, size.cols, 0)));
+    let parser = Arc::new(RwLock::new(vt100_ctt::Parser::new(size.rows, size.cols, 0)));
 
     {
         let parser = parser.clone();
@@ -112,7 +112,7 @@ fn main() -> std::io::Result<()> {
 
 fn run<B: Backend>(
     terminal: &mut Terminal<B>,
-    parser: Arc<RwLock<vt100::Parser>>,
+    parser: Arc<RwLock<vt100_ctt::Parser>>,
     sender: Sender<Bytes>,
 ) -> io::Result<()> {
     loop {
@@ -179,7 +179,7 @@ fn run<B: Backend>(
                 Event::Mouse(_) => {}
                 Event::Paste(_) => todo!(),
                 Event::Resize(cols, rows) => {
-                    parser.write().unwrap().set_size(rows, cols);
+                    parser.write().unwrap().screen_mut().set_size(rows, cols);
                 }
             }
         }

--- a/examples/nested_shell_async.rs
+++ b/examples/nested_shell_async.rs
@@ -24,7 +24,7 @@ use tokio::{
     task,
 };
 use tui_term::widget::PseudoTerminal;
-use vt100::Screen;
+use vt100_ctt::Screen;
 
 #[derive(Debug)]
 struct Size {
@@ -68,7 +68,7 @@ async fn main() -> io::Result<()> {
     });
 
     let mut reader = pair.master.try_clone_reader().unwrap();
-    let parser = Arc::new(RwLock::new(vt100::Parser::new(size.rows, size.cols, 0)));
+    let parser = Arc::new(RwLock::new(vt100_ctt::Parser::new(size.rows, size.cols, 0)));
 
     {
         let parser = parser.clone();
@@ -119,7 +119,7 @@ async fn main() -> io::Result<()> {
 
 async fn run<B: Backend>(
     terminal: &mut Terminal<B>,
-    parser: Arc<RwLock<vt100::Parser>>,
+    parser: Arc<RwLock<vt100_ctt::Parser>>,
     sender: Sender<Bytes>,
 ) -> io::Result<()> {
     loop {
@@ -182,7 +182,7 @@ async fn run<B: Backend>(
                 Event::Mouse(_) => {}
                 Event::Paste(_) => todo!(),
                 Event::Resize(cols, rows) => {
-                    parser.write().unwrap().set_size(rows, cols);
+                    parser.write().unwrap().screen_mut().set_size(rows, cols);
                 }
             }
         }

--- a/examples/simple_ls_chan.rs
+++ b/examples/simple_ls_chan.rs
@@ -18,7 +18,7 @@ use ratatui::{
     Frame, Terminal,
 };
 use tui_term::widget::PseudoTerminal;
-use vt100::Screen;
+use vt100_ctt::Screen;
 
 fn main() -> std::io::Result<()> {
     let (mut terminal, size) = setup_terminal().unwrap();
@@ -41,7 +41,7 @@ fn main() -> std::io::Result<()> {
 
     let (tx, rx) = channel();
     let mut reader = pair.master.try_clone_reader().unwrap();
-    let mut parser = vt100::Parser::new(size.rows - 1, size.cols - 1, 0);
+    let mut parser = vt100_ctt::Parser::new(size.rows - 1, size.cols - 1, 0);
 
     std::thread::spawn(move || {
         // Consume the output from the child

--- a/examples/simple_ls_controller.rs
+++ b/examples/simple_ls_controller.rs
@@ -15,7 +15,7 @@ use ratatui::{
     Frame, Terminal,
 };
 use tui_term::{controller::Controller, widget::PseudoTerminal};
-use vt100::Screen;
+use vt100_ctt::Screen;
 
 fn main() -> std::io::Result<()> {
     let (mut terminal, size) = setup_terminal().unwrap();
@@ -38,7 +38,7 @@ fn main() -> std::io::Result<()> {
     Ok(())
 }
 
-fn run<B: Backend>(terminal: &mut Terminal<B>, screen: Option<vt100::Screen>) -> io::Result<()> {
+fn run<B: Backend>(terminal: &mut Terminal<B>, screen: Option<vt100_ctt::Screen>) -> io::Result<()> {
     loop {
         if let Some(ref screen) = screen {
             terminal.draw(|f| ui(f, &screen))?;

--- a/examples/simple_ls_rw.rs
+++ b/examples/simple_ls_rw.rs
@@ -18,7 +18,7 @@ use ratatui::{
     Frame, Terminal,
 };
 use tui_term::widget::PseudoTerminal;
-use vt100::Screen;
+use vt100_ctt::Screen;
 
 fn main() -> std::io::Result<()> {
     let (mut terminal, size) = setup_terminal().unwrap();
@@ -40,7 +40,7 @@ fn main() -> std::io::Result<()> {
     drop(pair.slave);
 
     let mut reader = pair.master.try_clone_reader().unwrap();
-    let parser = Arc::new(RwLock::new(vt100::Parser::new(
+    let parser = Arc::new(RwLock::new(vt100_ctt::Parser::new(
         size.rows - 1,
         size.cols - 1,
         0,
@@ -77,7 +77,7 @@ fn main() -> std::io::Result<()> {
 
 fn run<B: Backend>(
     terminal: &mut Terminal<B>,
-    parser: Arc<RwLock<vt100::Parser>>,
+    parser: Arc<RwLock<vt100_ctt::Parser>>,
 ) -> io::Result<()> {
     loop {
         terminal.draw(|f| ui(f, parser.read().unwrap().screen()))?;

--- a/examples/smux.rs
+++ b/examples/smux.rs
@@ -164,7 +164,7 @@ fn resize_all_panes(panes: &mut Vec<PtyPane>, size: Size) {
 }
 
 struct PtyPane {
-    parser: Arc<RwLock<vt100::Parser>>,
+    parser: Arc<RwLock<vt100_ctt::Parser>>,
     sender: Sender<Bytes>,
     master_pty: Box<dyn MasterPty>,
 }
@@ -180,7 +180,7 @@ impl PtyPane {
                 pixel_height: 0,
             })
             .unwrap();
-        let parser = Arc::new(RwLock::new(vt100::Parser::new(
+        let parser = Arc::new(RwLock::new(vt100_ctt::Parser::new(
             size.rows - 4,
             size.cols - 4,
             0,
@@ -238,6 +238,7 @@ impl PtyPane {
         self.parser
             .write()
             .unwrap()
+            .screen_mut()
             .set_size(size.rows - 4, size.cols - 4);
         self.master_pty
             .resize(PtySize {

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -18,7 +18,7 @@ use std::{
 };
 
 use portable_pty::{CommandBuilder, ExitStatus, PtySystem};
-use vt100::{Parser, Screen};
+use vt100_ctt::{Parser, Screen};
 
 /// Controller, in charge of command dispatch
 pub struct Controller {
@@ -45,7 +45,7 @@ impl Controller {
         let mut child = pair.slave.spawn_command(self.cmd.clone()).unwrap();
         drop(pair.slave);
         let mut reader = pair.master.try_clone_reader().unwrap();
-        let parser = Arc::new(RwLock::new(vt100::Parser::new(
+        let parser = Arc::new(RwLock::new(vt100_ctt::Parser::new(
             self.size.rows,
             self.size.cols,
             0,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,9 +24,9 @@
 //!     widgets::{Block, Borders},
 //! };
 //! use tui_term::widget::PseudoTerminal;
-//! use vt100::Parser;
+//! use vt100_ctt::Parser;
 //!
-//! let mut parser = vt100::Parser::new(24, 80, 0);
+//! let mut parser = vt100_ctt::Parser::new(24, 80, 0);
 //! let pseudo_term = PseudoTerminal::new(parser.screen())
 //!     .block(Block::default().title("Terminal").borders(Borders::ALL))
 //!     .style(
@@ -41,11 +41,11 @@
 //!
 //! # Features
 //!
-//! - Support for parsing and processing terminal control sequences using the `vt100` crate.
+//! - Support for parsing and processing terminal control sequences using the `vt100_ctt` crate.
 //!
 //! # Limitations
 //!
-//! - The `vt100` crate is currently the only supported backend for parsing terminal control
+//! - The `vt100_ctt` crate is currently the only supported backend for parsing terminal control
 //!   sequences, but future versions may introduce support for alternative backends.
 
 mod state;
@@ -56,6 +56,6 @@ pub mod widget;
 #[cfg(feature = "unstable")]
 pub mod controller;
 
-/// Reexport of the vt100 crate to ensure correct version compatibility
+/// Reexport of the vt100_ctt crate to ensure correct version compatibility
 #[cfg(feature = "vt100")]
-pub use vt100;
+pub use vt100_ctt;

--- a/src/vt100_imp.rs
+++ b/src/vt100_imp.rs
@@ -2,8 +2,8 @@ use ratatui::style::{Modifier, Style};
 
 use crate::widget::{Cell, Screen};
 
-impl Screen for vt100::Screen {
-    type C = vt100::Cell;
+impl Screen for vt100_ctt::Screen {
+    type C = vt100_ctt::Cell;
 
     #[inline]
     fn cell(&self, row: u16, col: u16) -> Option<&Self::C> {
@@ -21,7 +21,7 @@ impl Screen for vt100::Screen {
     }
 }
 
-impl Cell for vt100::Cell {
+impl Cell for vt100_ctt::Cell {
     #[inline]
     fn has_contents(&self) -> bool {
         self.has_contents()
@@ -34,7 +34,7 @@ impl Cell for vt100::Cell {
 }
 
 #[inline]
-fn fill_buf_cell(screen_cell: &vt100::Cell, buf_cell: &mut ratatui::buffer::Cell) {
+fn fill_buf_cell(screen_cell: &vt100_ctt::Cell, buf_cell: &mut ratatui::buffer::Cell) {
     let fg = screen_cell.fgcolor();
     let bg = screen_cell.bgcolor();
     if screen_cell.has_contents() {
@@ -62,7 +62,7 @@ fn fill_buf_cell(screen_cell: &vt100::Cell, buf_cell: &mut ratatui::buffer::Cell
 
 /// Represents a foreground or background color for cells.
 /// Intermediate translation layer between
-/// [`vt100::Screen`] and [`ratatui::style::Color`]
+/// [`vt100_ctt::Screen`] and [`ratatui::style::Color`]
 #[allow(dead_code)]
 enum Color {
     Reset,
@@ -86,18 +86,18 @@ enum Color {
     Indexed(u8),
 }
 
-impl From<vt100::Color> for Color {
+impl From<vt100_ctt::Color> for Color {
     #[inline]
-    fn from(value: vt100::Color) -> Self {
+    fn from(value: vt100_ctt::Color) -> Self {
         match value {
-            vt100::Color::Default => Self::Reset,
-            vt100::Color::Idx(i) => Self::Indexed(i),
-            vt100::Color::Rgb(r, g, b) => Self::Rgb(r, g, b),
+            vt100_ctt::Color::Default => Self::Reset,
+            vt100_ctt::Color::Idx(i) => Self::Indexed(i),
+            vt100_ctt::Color::Rgb(r, g, b) => Self::Rgb(r, g, b),
         }
     }
 }
 
-impl From<Color> for vt100::Color {
+impl From<Color> for vt100_ctt::Color {
     #[inline]
     fn from(value: Color) -> Self {
         match value {

--- a/src/widget.rs
+++ b/src/widget.rs
@@ -9,7 +9,7 @@ use crate::state;
 
 /// A trait representing a pseudo-terminal screen.
 ///
-/// Implementing this trait allows for backends other than `vt100` to be used
+/// Implementing this trait allows for backends other than `vt100_ctt` to be used
 /// with the `PseudoTerminal` widget.
 pub trait Screen {
     /// The type of cell this screen contains
@@ -39,8 +39,8 @@ pub trait Cell {
 /// which is typically populated with text and control sequences from a terminal emulator.
 /// It provides a visual representation of the terminal output within a TUI application.
 ///
-/// The contents of the pseudo-terminal screen are represented by a `vt100::Screen` object.
-/// The `vt100` library provides functionality for parsing and processing terminal control sequences
+/// The contents of the pseudo-terminal screen are represented by a `vt100_ctt::Screen` object.
+/// The `vt100_ctt` library provides functionality for parsing and processing terminal control sequences
 /// and handling terminal state, allowing the `PseudoTerminal` widget to accurately render the
 /// terminal output.
 ///
@@ -52,9 +52,9 @@ pub trait Cell {
 ///     widgets::{Block, Borders},
 /// };
 /// use tui_term::widget::PseudoTerminal;
-/// use vt100::Parser;
+/// use vt100_ctt::Parser;
 ///
-/// let mut parser = vt100::Parser::new(24, 80, 0);
+/// let mut parser = vt100_ctt::Parser::new(24, 80, 0);
 /// let pseudo_term = PseudoTerminal::new(parser.screen())
 ///     .block(Block::default().title("Terminal").borders(Borders::ALL))
 ///     .style(
@@ -190,9 +190,9 @@ impl<'a, S: Screen> PseudoTerminal<'a, S> {
     ///
     /// ```
     /// use tui_term::widget::PseudoTerminal;
-    /// use vt100::Parser;
+    /// use vt100_ctt::Parser;
     ///
-    /// let mut parser = vt100::Parser::new(24, 80, 0);
+    /// let mut parser = vt100_ctt::Parser::new(24, 80, 0);
     /// let pseudo_term = PseudoTerminal::new(parser.screen());
     /// ```
     #[inline]
@@ -217,9 +217,9 @@ impl<'a, S: Screen> PseudoTerminal<'a, S> {
     /// ```
     /// use ratatui::widgets::Block;
     /// use tui_term::widget::PseudoTerminal;
-    /// use vt100::Parser;
+    /// use vt100_ctt::Parser;
     ///
-    /// let mut parser = vt100::Parser::new(24, 80, 0);
+    /// let mut parser = vt100_ctt::Parser::new(24, 80, 0);
     /// let block = Block::default();
     /// let pseudo_term = PseudoTerminal::new(parser.screen()).block(block);
     /// ```
@@ -245,7 +245,7 @@ impl<'a, S: Screen> PseudoTerminal<'a, S> {
     /// use ratatui::style::Style;
     /// use tui_term::widget::{Cursor, PseudoTerminal};
     ///
-    /// let mut parser = vt100::Parser::new(24, 80, 0);
+    /// let mut parser = vt100_ctt::Parser::new(24, 80, 0);
     /// let cursor = Cursor::default().symbol("|").style(Style::default());
     /// let pseudo_term = PseudoTerminal::new(parser.screen()).cursor(cursor);
     /// ```
@@ -268,7 +268,7 @@ impl<'a, S: Screen> PseudoTerminal<'a, S> {
     /// use ratatui::style::Style;
     /// use tui_term::widget::PseudoTerminal;
     ///
-    /// let mut parser = vt100::Parser::new(24, 80, 0);
+    /// let mut parser = vt100_ctt::Parser::new(24, 80, 0);
     /// let style = Style::default();
     /// let pseudo_term = PseudoTerminal::new(parser.screen()).style(style);
     /// ```
@@ -308,7 +308,7 @@ mod tests {
     fn snapshot_typescript(stream: &[u8]) -> String {
         let backend = TestBackend::new(80, 24);
         let mut terminal = Terminal::new(backend).unwrap();
-        let mut parser = vt100::Parser::new(24, 80, 0);
+        let mut parser = vt100_ctt::Parser::new(24, 80, 0);
         parser.process(stream);
         let pseudo_term = PseudoTerminal::new(parser.screen());
         terminal
@@ -323,7 +323,7 @@ mod tests {
     fn empty_actions() {
         let backend = TestBackend::new(80, 24);
         let mut terminal = Terminal::new(backend).unwrap();
-        let mut parser = vt100::Parser::new(24, 80, 0);
+        let mut parser = vt100_ctt::Parser::new(24, 80, 0);
         parser.process(b" ");
         let pseudo_term = PseudoTerminal::new(parser.screen());
         terminal
@@ -340,7 +340,7 @@ mod tests {
         // Make the backend on purpose much smaller
         let backend = TestBackend::new(80, 4);
         let mut terminal = Terminal::new(backend).unwrap();
-        let mut parser = vt100::Parser::new(24, 80, 0);
+        let mut parser = vt100_ctt::Parser::new(24, 80, 0);
         parser.process(stream);
         let pseudo_term = PseudoTerminal::new(parser.screen());
         terminal
@@ -363,7 +363,7 @@ mod tests {
         let stream = include_bytes!("../test/typescript/simple_ls.typescript");
         let backend = TestBackend::new(80, 24);
         let mut terminal = Terminal::new(backend).unwrap();
-        let mut parser = vt100::Parser::new(24, 80, 0);
+        let mut parser = vt100_ctt::Parser::new(24, 80, 0);
         let cursor = Cursor::default().symbol("|");
         parser.process(stream);
         let pseudo_term = PseudoTerminal::new(parser.screen()).cursor(cursor);
@@ -380,7 +380,7 @@ mod tests {
         let stream = include_bytes!("../test/typescript/simple_ls.typescript");
         let backend = TestBackend::new(80, 24);
         let mut terminal = Terminal::new(backend).unwrap();
-        let mut parser = vt100::Parser::new(24, 80, 0);
+        let mut parser = vt100_ctt::Parser::new(24, 80, 0);
         let style = Style::default().bg(Color::Cyan).fg(Color::LightRed);
         let cursor = Cursor::default().symbol("|").style(style);
         parser.process(stream);
@@ -398,7 +398,7 @@ mod tests {
         let stream = include_bytes!("../test/typescript/simple_ls.typescript");
         let backend = TestBackend::new(80, 24);
         let mut terminal = Terminal::new(backend).unwrap();
-        let mut parser = vt100::Parser::new(24, 80, 0);
+        let mut parser = vt100_ctt::Parser::new(24, 80, 0);
         let cursor = Cursor::default().visibility(false);
         parser.process(stream);
         let pseudo_term = PseudoTerminal::new(parser.screen()).cursor(cursor);
@@ -415,7 +415,7 @@ mod tests {
         let stream = include_bytes!("../test/typescript/simple_ls.typescript");
         let backend = TestBackend::new(80, 24);
         let mut terminal = Terminal::new(backend).unwrap();
-        let mut parser = vt100::Parser::new(24, 80, 0);
+        let mut parser = vt100_ctt::Parser::new(24, 80, 0);
         let mut cursor = Cursor::default();
         cursor.hide();
         parser.process(stream);
@@ -439,7 +439,7 @@ mod tests {
         let stream = include_bytes!("../test/typescript/overlapping_cursor.typescript");
         let backend = TestBackend::new(80, 24);
         let mut terminal = Terminal::new(backend).unwrap();
-        let mut parser = vt100::Parser::new(24, 80, 0);
+        let mut parser = vt100_ctt::Parser::new(24, 80, 0);
         let style = Style::default().bg(Color::Cyan).fg(Color::LightRed);
         let cursor = Cursor::default().overlay_style(style);
         parser.process(stream);
@@ -457,7 +457,7 @@ mod tests {
         let stream = include_bytes!("../test/typescript/simple_ls.typescript");
         let backend = TestBackend::new(100, 24);
         let mut terminal = Terminal::new(backend).unwrap();
-        let mut parser = vt100::Parser::new(24, 80, 0);
+        let mut parser = vt100_ctt::Parser::new(24, 80, 0);
         parser.process(stream);
         let block = Block::default().borders(Borders::ALL).title("ls");
         let pseudo_term = PseudoTerminal::new(parser.screen()).block(block);
@@ -474,7 +474,7 @@ mod tests {
         let stream = include_bytes!("../test/typescript/simple_ls.typescript");
         let backend = TestBackend::new(100, 24);
         let mut terminal = Terminal::new(backend).unwrap();
-        let mut parser = vt100::Parser::new(24, 80, 0);
+        let mut parser = vt100_ctt::Parser::new(24, 80, 0);
         parser.process(stream);
         let block = Block::default()
             .borders(Borders::ALL)


### PR DESCRIPTION
# Description

Use patched version of `vt100` so that the famous panic when scrolling bug gets resolved. 

Used crate `vt100-ctt` https://github.com/ChrisTitusTech/vt100-rust https://crates.io/crates/vt100-ctt

This prevents panic when scroll is used where the scroll offset is more than the number of rows.

The feature name `vt100` stays the same. No changes in feature names.

Related to https://github.com/a-kenji/tui-term/issues/239

# Testing

![image](https://github.com/user-attachments/assets/3da0a079-731d-4940-915c-a948be316d4e)
