### PR TITLE
examples: Simplify examples through new `ratatui::init` functions

### DIFF
--- a/examples/long_running.rs
+++ b/examples/long_running.rs
@@ -1,36 +1,29 @@
 use std::{
-    io,
+    io::{self, Read},
     sync::{Arc, RwLock},
     time::Duration,
 };
 
-use crossterm::{
-    event::{self, DisableMouseCapture, EnableMouseCapture, Event, KeyCode, KeyEventKind},
-    execute,
-    style::ResetColor,
-    terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
-};
+use crossterm::event::{self, Event, KeyCode, KeyEventKind};
 use portable_pty::{CommandBuilder, NativePtySystem, PtySize, PtySystem};
 use ratatui::{
-    backend::{Backend, CrosstermBackend},
     layout::Alignment,
     style::{Modifier, Style},
     text::Line,
     widgets::{Block, Borders, Paragraph},
-    Frame, Terminal,
+    DefaultTerminal, Frame,
 };
 use tui_term::widget::PseudoTerminal;
 use vt100::Screen;
 
 fn main() -> std::io::Result<()> {
-    let mut stdout = io::stdout();
-    execute!(stdout, ResetColor)?;
-    enable_raw_mode()?;
-    let mut stdout = io::stdout();
-    execute!(stdout, EnterAlternateScreen, EnableMouseCapture)?;
-    let backend = CrosstermBackend::new(stdout);
-    let mut terminal = Terminal::new(backend)?;
+    let mut terminal = ratatui::init();
+    let result = run_app(&mut terminal);
+    ratatui::restore();
+    result
+}
 
+fn run_app(terminal: &mut DefaultTerminal) -> std::io::Result<()> {
     let pty_system = NativePtySystem::default();
     let cwd = std::env::current_dir().unwrap();
     let mut cmd = CommandBuilder::new("top");
@@ -84,23 +77,10 @@ fn main() -> std::io::Result<()> {
     }
     drop(pair.master);
 
-    run(&mut terminal, parser)?;
-
-    // restore terminal
-    disable_raw_mode()?;
-    execute!(
-        terminal.backend_mut(),
-        LeaveAlternateScreen,
-        DisableMouseCapture
-    )?;
-    terminal.show_cursor()?;
-    Ok(())
+    run(terminal, parser)
 }
 
-fn run<B: Backend>(
-    terminal: &mut Terminal<B>,
-    parser: Arc<RwLock<vt100::Parser>>,
-) -> io::Result<()> {
+fn run(terminal: &mut DefaultTerminal, parser: Arc<RwLock<vt100::Parser>>) -> io::Result<()> {
     loop {
         terminal.draw(|f| ui(f, parser.read().unwrap().screen()))?;
 

--- a/examples/nested_shell.rs
+++ b/examples/nested_shell.rs
@@ -1,23 +1,17 @@
 use std::{
-    io,
+    io::{self, Read, Write},
     sync::{mpsc::Sender, Arc, RwLock},
     time::Duration,
 };
 
 use bytes::Bytes;
-use crossterm::{
-    event::{self, Event, KeyCode, KeyEventKind},
-    execute,
-    style::ResetColor,
-    terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
-};
+use crossterm::event::{self, Event, KeyCode, KeyEventKind};
 use portable_pty::{CommandBuilder, NativePtySystem, PtySize, PtySystem};
 use ratatui::{
-    backend::{Backend, CrosstermBackend},
     layout::Alignment,
     style::{Modifier, Style},
     widgets::{Block, Borders, Paragraph},
-    Frame, Terminal,
+    DefaultTerminal, Frame,
 };
 use tui_term::widget::PseudoTerminal;
 use vt100::Screen;
@@ -29,23 +23,22 @@ struct Size {
 }
 
 fn main() -> std::io::Result<()> {
-    let mut stdout = io::stdout();
-    execute!(stdout, ResetColor)?;
-    enable_raw_mode()?;
-    let mut stdout = io::stdout();
-    execute!(stdout, EnterAlternateScreen)?;
-    let backend = CrosstermBackend::new(stdout);
-    let mut terminal = Terminal::new(backend)?;
+    let mut terminal = ratatui::init();
+    let result = run_app(&mut terminal);
+    ratatui::restore();
+    result
+}
+
+fn run_app(terminal: &mut DefaultTerminal) -> std::io::Result<()> {
+    let size = Size {
+        rows: terminal.size()?.height,
+        cols: terminal.size()?.width,
+    };
 
     let pty_system = NativePtySystem::default();
     let cwd = std::env::current_dir().unwrap();
     let mut cmd = CommandBuilder::new_default_prog();
     cmd.cwd(cwd);
-
-    let size = Size {
-        rows: terminal.size()?.height,
-        cols: terminal.size()?.width,
-    };
 
     let pair = pty_system
         .openpty(PtySize {
@@ -100,18 +93,13 @@ fn main() -> std::io::Result<()> {
         drop(pair.master);
     });
 
-    run(&mut terminal, parser, tx)?;
-
-    // restore terminal
-    disable_raw_mode()?;
-    execute!(terminal.backend_mut(), LeaveAlternateScreen,)?;
-    terminal.show_cursor()?;
+    let result = run(terminal, parser, tx);
     println!("{size:?}");
-    Ok(())
+    result
 }
 
-fn run<B: Backend>(
-    terminal: &mut Terminal<B>,
+fn run(
+    terminal: &mut DefaultTerminal,
     parser: Arc<RwLock<vt100::Parser>>,
     sender: Sender<Bytes>,
 ) -> io::Result<()> {

--- a/examples/nested_shell_async.rs
+++ b/examples/nested_shell_async.rs
@@ -5,19 +5,13 @@ use std::{
 };
 
 use bytes::Bytes;
-use crossterm::{
-    event::{self, Event, KeyCode, KeyEventKind},
-    execute,
-    style::ResetColor,
-    terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
-};
+use crossterm::event::{self, Event, KeyCode, KeyEventKind};
 use portable_pty::{CommandBuilder, NativePtySystem, PtySize, PtySystem};
 use ratatui::{
-    backend::{Backend, CrosstermBackend},
     layout::Alignment,
     style::{Modifier, Style},
     widgets::{Block, Borders, Paragraph},
-    Frame, Terminal,
+    DefaultTerminal, Frame,
 };
 use tokio::{
     sync::mpsc::{channel, Sender},
@@ -34,14 +28,13 @@ struct Size {
 
 #[tokio::main]
 async fn main() -> io::Result<()> {
-    let mut stdout = io::stdout();
-    execute!(stdout, ResetColor)?;
-    enable_raw_mode()?;
-    let mut stdout = io::stdout();
-    execute!(stdout, EnterAlternateScreen)?;
-    let backend = CrosstermBackend::new(stdout);
-    let mut terminal = Terminal::new(backend)?;
+    let mut terminal = ratatui::init();
+    let result = run_app(&mut terminal).await;
+    ratatui::restore();
+    result
+}
 
+async fn run_app(terminal: &mut DefaultTerminal) -> io::Result<()> {
     let pty_system = NativePtySystem::default();
     let cwd = std::env::current_dir().unwrap();
     let mut cmd = CommandBuilder::new_default_prog();
@@ -107,18 +100,13 @@ async fn main() -> io::Result<()> {
         drop(pair.master);
     });
 
-    run(&mut terminal, parser, tx).await?;
-
-    // restore terminal
-    disable_raw_mode()?;
-    execute!(terminal.backend_mut(), LeaveAlternateScreen,)?;
-    terminal.show_cursor()?;
+    let result = run(terminal, parser, tx).await;
     println!("{size:?}");
-    Ok(())
+    result
 }
 
-async fn run<B: Backend>(
-    terminal: &mut Terminal<B>,
+async fn run(
+    terminal: &mut DefaultTerminal,
     parser: Arc<RwLock<vt100::Parser>>,
     sender: Sender<Bytes>,
 ) -> io::Result<()> {

--- a/examples/simple_ls_chan.rs
+++ b/examples/simple_ls_chan.rs
@@ -1,27 +1,30 @@
-use std::{
-    io::{self, BufWriter},
-    sync::mpsc::channel,
-};
+use std::{io, sync::mpsc::channel};
 
-use crossterm::{
-    event::{self, Event, KeyCode, KeyEventKind},
-    execute,
-    terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
-};
+use crossterm::event::{self, Event, KeyCode, KeyEventKind};
 use portable_pty::{CommandBuilder, NativePtySystem, PtySize, PtySystem};
 use ratatui::{
-    backend::{Backend, CrosstermBackend},
     layout::Alignment,
     style::{Modifier, Style},
     text::Line,
     widgets::{Block, Borders, Paragraph},
-    Frame, Terminal,
+    DefaultTerminal, Frame,
 };
 use tui_term::widget::PseudoTerminal;
 use vt100::Screen;
 
 fn main() -> std::io::Result<()> {
-    let (mut terminal, size) = setup_terminal().unwrap();
+    let mut terminal = ratatui::init();
+    let result = run_app(&mut terminal);
+    ratatui::restore();
+    result
+}
+
+fn run_app(terminal: &mut DefaultTerminal) -> std::io::Result<()> {
+    let terminal_size = terminal.size()?;
+    let size = Size {
+        rows: terminal_size.height,
+        cols: terminal_size.width,
+    };
 
     let pty_system = NativePtySystem::default();
     let cwd = std::env::current_dir().unwrap();
@@ -63,14 +66,10 @@ fn main() -> std::io::Result<()> {
     let output = rx.recv().unwrap();
     parser.process(output.as_bytes());
 
-    run(&mut terminal, parser.screen())?;
-
-    // restore terminal
-    cleanup_terminal(&mut terminal).unwrap();
-    Ok(())
+    run(terminal, parser.screen())
 }
 
-fn run<B: Backend>(terminal: &mut Terminal<B>, screen: &Screen) -> io::Result<()> {
+fn run(terminal: &mut DefaultTerminal, screen: &Screen) -> io::Result<()> {
     loop {
         terminal.draw(|f| ui(f, screen))?;
 
@@ -113,30 +112,6 @@ fn ui(f: &mut Frame, screen: &Screen) {
         .style(Style::default().add_modifier(Modifier::BOLD | Modifier::REVERSED))
         .alignment(Alignment::Center);
     f.render_widget(explanation, chunks[2]);
-}
-
-fn setup_terminal() -> io::Result<(Terminal<CrosstermBackend<BufWriter<io::Stdout>>>, Size)> {
-    enable_raw_mode()?;
-    let stdout = io::stdout();
-    let backend = CrosstermBackend::new(BufWriter::new(stdout));
-    let mut terminal = Terminal::new(backend)?;
-    let initial_size = terminal.size()?;
-    let size = Size {
-        rows: initial_size.height,
-        cols: initial_size.width,
-    };
-    execute!(terminal.backend_mut(), EnterAlternateScreen)?;
-    Ok((terminal, size))
-}
-
-fn cleanup_terminal(
-    terminal: &mut Terminal<CrosstermBackend<BufWriter<io::Stdout>>>,
-) -> io::Result<()> {
-    execute!(terminal.backend_mut(), LeaveAlternateScreen)?;
-    disable_raw_mode()?;
-    terminal.show_cursor()?;
-    terminal.clear()?;
-    Ok(())
 }
 
 #[derive(Debug, Clone)]

--- a/examples/simple_ls_controller.rs
+++ b/examples/simple_ls_controller.rs
@@ -1,24 +1,30 @@
-use std::io::{self, BufWriter};
+use std::io;
 
-use crossterm::{
-    event::{self, Event, KeyCode, KeyEventKind},
-    execute,
-    terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
-};
+use crossterm::event::{self, Event, KeyCode, KeyEventKind};
 use portable_pty::CommandBuilder;
 use ratatui::{
-    backend::{Backend, CrosstermBackend},
     layout::Alignment,
     style::{Modifier, Style},
     text::Line,
     widgets::{Block, Borders, Paragraph},
-    Frame, Terminal,
+    DefaultTerminal, Frame,
 };
 use tui_term::{controller::Controller, widget::PseudoTerminal};
 use vt100::Screen;
 
 fn main() -> std::io::Result<()> {
-    let (mut terminal, size) = setup_terminal().unwrap();
+    let mut terminal = ratatui::init();
+    let result = run_app(&mut terminal);
+    ratatui::restore();
+    result
+}
+
+fn run_app(terminal: &mut DefaultTerminal) -> std::io::Result<()> {
+    let terminal_size = terminal.size()?;
+    let size = Size {
+        rows: terminal_size.height,
+        cols: terminal_size.width,
+    };
 
     // Subtract the borders from the size
     let size = tui_term::controller::Size::new(size.cols - 2, size.rows, 0, 0);
@@ -32,13 +38,10 @@ fn main() -> std::io::Result<()> {
     controller.run();
     let screen = controller.screen();
 
-    run(&mut terminal, screen)?;
-
-    cleanup_terminal(&mut terminal).unwrap();
-    Ok(())
+    run(terminal, screen)
 }
 
-fn run<B: Backend>(terminal: &mut Terminal<B>, screen: Option<vt100::Screen>) -> io::Result<()> {
+fn run(terminal: &mut DefaultTerminal, screen: Option<vt100::Screen>) -> io::Result<()> {
     loop {
         if let Some(ref screen) = screen {
             terminal.draw(|f| ui(f, &screen))?;
@@ -80,30 +83,6 @@ fn ui(f: &mut Frame, screen: &Screen) {
         .style(Style::default().add_modifier(Modifier::BOLD | Modifier::REVERSED))
         .alignment(Alignment::Center);
     f.render_widget(explanation, chunks[1]);
-}
-
-fn setup_terminal() -> io::Result<(Terminal<CrosstermBackend<BufWriter<io::Stdout>>>, Size)> {
-    enable_raw_mode()?;
-    let stdout = io::stdout();
-    let backend = CrosstermBackend::new(BufWriter::new(stdout));
-    let mut terminal = Terminal::new(backend)?;
-    let initial_size = terminal.size()?;
-    let size = Size {
-        rows: initial_size.height,
-        cols: initial_size.width,
-    };
-    execute!(terminal.backend_mut(), EnterAlternateScreen)?;
-    Ok((terminal, size))
-}
-
-fn cleanup_terminal(
-    terminal: &mut Terminal<CrosstermBackend<BufWriter<io::Stdout>>>,
-) -> io::Result<()> {
-    execute!(terminal.backend_mut(), LeaveAlternateScreen)?;
-    disable_raw_mode()?;
-    terminal.show_cursor()?;
-    terminal.clear()?;
-    Ok(())
 }
 
 #[derive(Debug, Clone)]

--- a/examples/simple_ls_rw.rs
+++ b/examples/simple_ls_rw.rs
@@ -1,27 +1,33 @@
 use std::{
-    io::{self, BufWriter},
+    io,
     sync::{Arc, RwLock},
 };
 
-use crossterm::{
-    event::{self, Event, KeyCode, KeyEventKind},
-    execute,
-    terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
-};
+use crossterm::event::{self, Event, KeyCode, KeyEventKind};
 use portable_pty::{CommandBuilder, NativePtySystem, PtySize, PtySystem};
 use ratatui::{
-    backend::{Backend, CrosstermBackend},
     layout::Alignment,
     style::{Modifier, Style},
     text::Line,
     widgets::{Block, Borders, Paragraph},
-    Frame, Terminal,
+    DefaultTerminal, Frame,
 };
 use tui_term::widget::PseudoTerminal;
 use vt100::Screen;
 
 fn main() -> std::io::Result<()> {
-    let (mut terminal, size) = setup_terminal().unwrap();
+    let mut terminal = ratatui::init();
+    let result = run_app(&mut terminal);
+    ratatui::restore();
+    result
+}
+
+fn run_app(terminal: &mut DefaultTerminal) -> std::io::Result<()> {
+    let terminal_size = terminal.size()?;
+    let size = Size {
+        rows: terminal_size.height,
+        cols: terminal_size.width,
+    };
 
     let pty_system = NativePtySystem::default();
     let cwd = std::env::current_dir().unwrap();
@@ -69,16 +75,10 @@ fn main() -> std::io::Result<()> {
 
     drop(pair.master);
 
-    run(&mut terminal, parser)?;
-
-    cleanup_terminal(&mut terminal).unwrap();
-    Ok(())
+    run(terminal, parser)
 }
 
-fn run<B: Backend>(
-    terminal: &mut Terminal<B>,
-    parser: Arc<RwLock<vt100::Parser>>,
-) -> io::Result<()> {
+fn run(terminal: &mut DefaultTerminal, parser: Arc<RwLock<vt100::Parser>>) -> io::Result<()> {
     loop {
         terminal.draw(|f| ui(f, parser.read().unwrap().screen()))?;
 
@@ -121,30 +121,6 @@ fn ui(f: &mut Frame, screen: &Screen) {
         .style(Style::default().add_modifier(Modifier::BOLD | Modifier::REVERSED))
         .alignment(Alignment::Center);
     f.render_widget(explanation, chunks[2]);
-}
-
-fn setup_terminal() -> io::Result<(Terminal<CrosstermBackend<BufWriter<io::Stdout>>>, Size)> {
-    enable_raw_mode()?;
-    let stdout = io::stdout();
-    let backend = CrosstermBackend::new(BufWriter::new(stdout));
-    let mut terminal = Terminal::new(backend)?;
-    let initial_size = terminal.size()?;
-    let size = Size {
-        rows: initial_size.height,
-        cols: initial_size.width,
-    };
-    execute!(terminal.backend_mut(), EnterAlternateScreen)?;
-    Ok((terminal, size))
-}
-
-fn cleanup_terminal(
-    terminal: &mut Terminal<CrosstermBackend<BufWriter<io::Stdout>>>,
-) -> io::Result<()> {
-    execute!(terminal.backend_mut(), LeaveAlternateScreen)?;
-    disable_raw_mode()?;
-    terminal.show_cursor()?;
-    terminal.clear()?;
-    Ok(())
 }
 
 #[derive(Debug, Clone)]

--- a/examples/smux.rs
+++ b/examples/smux.rs
@@ -10,18 +10,13 @@ use std::{
 };
 
 use bytes::Bytes;
-use crossterm::{
-    event::{self, Event, KeyCode, KeyEvent, KeyModifiers},
-    execute,
-    terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
-};
+use crossterm::event::{self, Event, KeyCode, KeyEvent, KeyModifiers};
 use portable_pty::{native_pty_system, CommandBuilder, MasterPty, PtySize};
 use ratatui::{
-    backend::CrosstermBackend,
     layout::{Alignment, Constraint, Direction, Layout, Rect},
     style::{Color, Modifier, Style},
     widgets::{Block, Borders, Paragraph},
-    Terminal,
+    DefaultTerminal,
 };
 use tokio::{
     sync::mpsc::{channel, Sender},
@@ -40,7 +35,17 @@ struct Size {
 #[tokio::main]
 async fn main() -> io::Result<()> {
     init_panic_hook();
-    let (mut terminal, mut size) = setup_terminal().unwrap();
+    let mut terminal = ratatui::init();
+    let result = run_smux(&mut terminal).await;
+    ratatui::restore();
+    result
+}
+
+async fn run_smux(terminal: &mut DefaultTerminal) -> io::Result<()> {
+    let mut size = Size {
+        rows: terminal.size()?.height,
+        cols: terminal.size()?.width,
+    };
 
     let cwd = std::env::current_dir().unwrap();
     let mut cmd = CommandBuilder::new_default_prog();
@@ -107,7 +112,6 @@ async fn main() -> io::Result<()> {
             match event::read()? {
                 Event::Key(key) => match key.code {
                     KeyCode::Char('q') if key.modifiers.contains(KeyModifiers::CONTROL) => {
-                        cleanup_terminal(&mut terminal).unwrap();
                         return Ok(());
                     }
                     KeyCode::Char('n') if key.modifiers.contains(KeyModifiers::CONTROL) => {
@@ -154,7 +158,6 @@ async fn main() -> io::Result<()> {
         cleanup_exited_panes(&mut panes, &mut active_pane);
 
         if panes.is_empty() {
-            cleanup_terminal(&mut terminal)?;
             return Ok(());
         }
     }
@@ -386,30 +389,6 @@ async fn close_active_pane(
     Ok(())
 }
 
-fn setup_terminal() -> io::Result<(Terminal<CrosstermBackend<BufWriter<io::Stdout>>>, Size)> {
-    enable_raw_mode()?;
-    let stdout = io::stdout();
-    let backend = CrosstermBackend::new(BufWriter::new(stdout));
-    let mut terminal = Terminal::new(backend)?;
-    let initial_size = terminal.size()?;
-    let size = Size {
-        rows: initial_size.height,
-        cols: initial_size.width,
-    };
-    execute!(terminal.backend_mut(), EnterAlternateScreen)?;
-    Ok((terminal, size))
-}
-
-fn cleanup_terminal(
-    terminal: &mut Terminal<CrosstermBackend<BufWriter<io::Stdout>>>,
-) -> io::Result<()> {
-    execute!(terminal.backend_mut(), LeaveAlternateScreen)?;
-    disable_raw_mode()?;
-    terminal.show_cursor()?;
-    terminal.clear()?;
-    Ok(())
-}
-
 fn init_panic_hook() {
     let log_file = Some(PathBuf::from("/tmp/tui-term/smux.log"));
     let log_file = match log_file {
@@ -438,9 +417,7 @@ fn init_panic_hook() {
     std::panic::set_hook(Box::new(|panic| {
         let original_hook = std::panic::take_hook();
         tracing::error!("Panic Error: {}", panic);
-        crossterm::terminal::disable_raw_mode().expect("Could not disable raw mode");
-        crossterm::execute!(std::io::stdout(), crossterm::terminal::LeaveAlternateScreen)
-            .expect("Could not leave the alternate screen");
+        ratatui::restore();
 
         original_hook(panic);
     }));


### PR DESCRIPTION
Simplify the examples through the new initialization functionality from
`ratatui`.
