### PR TITLE
chore(deps): update vt100

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -682,9 +682,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.11"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
+checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
 name = "js-sys"
@@ -789,9 +789,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.7.2"
+version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8640c5d730cb13ebd907d8d04b52f55ac9a2eec55b440c8892f40d56c76c1d"
+checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
 name = "memmem"
@@ -1192,7 +1192,7 @@ dependencies = [
  "thiserror 2.0.17",
  "unicode-segmentation",
  "unicode-truncate",
- "unicode-width 0.2.0",
+ "unicode-width",
 ]
 
 [[package]]
@@ -1243,7 +1243,7 @@ dependencies = [
  "strum",
  "time",
  "unicode-segmentation",
- "unicode-width 0.2.0",
+ "unicode-width",
 ]
 
 [[package]]
@@ -1880,20 +1880,14 @@ checksum = "8fbf03860ff438702f3910ca5f28f8dac63c1c11e7efb5012b8b175493606330"
 dependencies = [
  "itertools 0.13.0",
  "unicode-segmentation",
- "unicode-width 0.2.0",
+ "unicode-width",
 ]
 
 [[package]]
 name = "unicode-width"
-version = "0.1.13"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0336d538f7abc86d282a4189614dfaa90810dfc2c6f6427eaf88e16311dd225d"
-
-[[package]]
-name = "unicode-width"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
 name = "utf8parse"
@@ -1927,35 +1921,23 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "vt100"
-version = "0.15.2"
+version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84cd863bf0db7e392ba3bd04994be3473491b31e66340672af5d11943c6274de"
+checksum = "054ff75fb8fa83e609e685106df4faeffdf3a735d3c74ebce97ec557d5d36fd9"
 dependencies = [
  "itoa",
- "log",
- "unicode-width 0.1.13",
+ "unicode-width",
  "vte",
 ]
 
 [[package]]
 name = "vte"
-version = "0.11.1"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5022b5fbf9407086c180e9557be968742d839e68346af7792b8592489732197"
+checksum = "a5924018406ce0063cd67f8e008104968b74b563ee1b85dde3ed1f7cb87d3dbd"
 dependencies = [
  "arrayvec",
- "utf8parse",
- "vte_generate_state_changes",
-]
-
-[[package]]
-name = "vte_generate_state_changes"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d257817081c7dffcdbab24b9e62d2def62e2ff7d00b1c20062551e6cccc145ff"
-dependencies = [
- "proc-macro2",
- "quote",
+ "memchr",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ unstable = ["dep:portable-pty"]
 [dependencies]
 ratatui-core = { version = "0.1.0", default-features = false }
 ratatui-widgets = { version = "0.3.0", default-features = false }
-vt100 = { version = "0.15.2", optional = true }
+vt100 = { version = "0.16.2", optional = true }
 portable-pty = { version = "0.9.0", optional = true }
 
 [dev-dependencies]

--- a/examples/nested_shell.rs
+++ b/examples/nested_shell.rs
@@ -167,7 +167,7 @@ fn run(
                 Event::Mouse(_) => {}
                 Event::Paste(_) => todo!(),
                 Event::Resize(cols, rows) => {
-                    parser.write().unwrap().set_size(rows, cols);
+                    parser.write().unwrap().screen_mut().set_size(rows, cols);
                 }
             }
         }

--- a/examples/nested_shell_async.rs
+++ b/examples/nested_shell_async.rs
@@ -170,7 +170,7 @@ async fn run(
                 Event::Mouse(_) => {}
                 Event::Paste(_) => todo!(),
                 Event::Resize(cols, rows) => {
-                    parser.write().unwrap().set_size(rows, cols);
+                    parser.write().unwrap().screen_mut().set_size(rows, cols);
                 }
             }
         }

--- a/examples/smux.rs
+++ b/examples/smux.rs
@@ -283,6 +283,7 @@ impl PtyPane {
         self.parser
             .write()
             .unwrap()
+            .screen_mut()
             .set_size(size.rows - 4, size.cols - 4);
         self.master_pty
             .resize(PtySize {
@@ -429,10 +430,6 @@ impl fmt::Debug for PtyPane {
         let parser = self.parser.read().unwrap();
         let screen = parser.screen();
 
-        f.debug_struct("PtyPane")
-            .field("screen", screen)
-            .field("title:", &screen.title())
-            .field("icon_name:", &screen.icon_name())
-            .finish()
+        f.debug_struct("PtyPane").field("screen", screen).finish()
     }
 }


### PR DESCRIPTION
Resolves #330 

It appears some of the getter methods like `title` and `icon_name` were [removed](https://github.com/doy/vt100-rust/commit/811c4a9c2744643dd7289579fb69d9eba1e5581b), so I had to remove those.