### PR TITLE
Add dim/faint text support (SGR 2)

### DIFF
--- a/src/snapshots/tui_term__widget__tests__dim_bold_text.snap
+++ b/src/snapshots/tui_term__widget__tests__dim_bold_text.snap
@@ -1,0 +1,39 @@
+---
+source: src/widget.rs
+expression: view
+---
+Buffer {
+    area: Rect { x: 0, y: 0, width: 80, height: 24 },
+    content: [
+        "This is dim and bold. Bold takes precedence. Normal.█                           ",
+        "                                                                                ",
+        "                                                                                ",
+        "                                                                                ",
+        "                                                                                ",
+        "                                                                                ",
+        "                                                                                ",
+        "                                                                                ",
+        "                                                                                ",
+        "                                                                                ",
+        "                                                                                ",
+        "                                                                                ",
+        "                                                                                ",
+        "                                                                                ",
+        "                                                                                ",
+        "                                                                                ",
+        "                                                                                ",
+        "                                                                                ",
+        "                                                                                ",
+        "                                                                                ",
+        "                                                                                ",
+        "                                                                                ",
+        "                                                                                ",
+        "                                                                                ",
+    ],
+    styles: [
+        x: 0, y: 0, fg: Reset, bg: Reset, underline: Reset, modifier: BOLD,
+        x: 44, y: 0, fg: Reset, bg: Reset, underline: Reset, modifier: NONE,
+        x: 52, y: 0, fg: Gray, bg: Reset, underline: Reset, modifier: NONE,
+        x: 53, y: 0, fg: Reset, bg: Reset, underline: Reset, modifier: NONE,
+    ]
+}

--- a/src/snapshots/tui_term__widget__tests__dim_text.snap
+++ b/src/snapshots/tui_term__widget__tests__dim_text.snap
@@ -1,0 +1,39 @@
+---
+source: src/widget.rs
+expression: view
+---
+Buffer {
+    area: Rect { x: 0, y: 0, width: 80, height: 24 },
+    content: [
+        "This line will be displayed dim/faint. This should have no style.█              ",
+        "                                                                                ",
+        "                                                                                ",
+        "                                                                                ",
+        "                                                                                ",
+        "                                                                                ",
+        "                                                                                ",
+        "                                                                                ",
+        "                                                                                ",
+        "                                                                                ",
+        "                                                                                ",
+        "                                                                                ",
+        "                                                                                ",
+        "                                                                                ",
+        "                                                                                ",
+        "                                                                                ",
+        "                                                                                ",
+        "                                                                                ",
+        "                                                                                ",
+        "                                                                                ",
+        "                                                                                ",
+        "                                                                                ",
+        "                                                                                ",
+        "                                                                                ",
+    ],
+    styles: [
+        x: 0, y: 0, fg: Reset, bg: Reset, underline: Reset, modifier: DIM,
+        x: 38, y: 0, fg: Reset, bg: Reset, underline: Reset, modifier: NONE,
+        x: 65, y: 0, fg: Gray, bg: Reset, underline: Reset, modifier: NONE,
+        x: 66, y: 0, fg: Reset, bg: Reset, underline: Reset, modifier: NONE,
+    ]
+}

--- a/src/vt100_imp.rs
+++ b/src/vt100_imp.rs
@@ -55,6 +55,9 @@ fn fill_buf_cell(screen_cell: &vt100::Cell, buf_cell: &mut ratatui_core::buffer:
     if screen_cell.inverse() {
         style = style.add_modifier(Modifier::REVERSED);
     }
+    if screen_cell.dim() {
+        style = style.add_modifier(Modifier::DIM);
+    }
     buf_cell.set_style(style);
     buf_cell.set_fg(fg.into());
     buf_cell.set_bg(bg.into());

--- a/src/widget.rs
+++ b/src/widget.rs
@@ -516,9 +516,22 @@ mod tests {
         insta::assert_snapshot!(view);
     }
     #[test]
+    fn dim_text() {
+        let stream =
+            b"\x1b[2mThis line will be displayed dim/faint.\x1b[0m This should have no style.";
+        let view = snapshot_typescript(stream);
+        insta::assert_snapshot!(view);
+    }
+    #[test]
     fn combined_modifier_text() {
         let stream =
             b"[4m[3mThis line will be displayed in italic and underlined.[0m This should have no style.";
+        let view = snapshot_typescript(stream);
+        insta::assert_snapshot!(view);
+    }
+    #[test]
+    fn dim_bold_text() {
+        let stream = b"\x1b[2m\x1b[1mThis is dim and bold. Bold takes precedence.\x1b[0m Normal.";
         let view = snapshot_typescript(stream);
         insta::assert_snapshot!(view);
     }


### PR DESCRIPTION
## Summary
   - Map vt100's `dim()` attribute to ratatui's `Modifier::DIM` for proper rendering of faint/grayed out text

   ## Background
   When terminal applications output text with SGR 2 (dim/faint attribute), vt100 correctly parses this and exposes it via `cell.dim()`.
   However, tui-term wasn't converting this to ratatui's `Modifier::DIM`, causing faint text to render as normal text.

   This is noticeable in applications like Claude Code which uses dim text for suggested prompts.

   ## Test plan
   - [x] Verified dim text renders correctly in a TUI application using tui-term