### PR TITLE
widget!: implement `Widget` for `&PseudoTerminal`

### DIFF
--- a/src/widget.rs
+++ b/src/widget.rs
@@ -285,7 +285,7 @@ impl<'a, S: Screen> PseudoTerminal<'a, S> {
     }
 }
 
-impl<S: Screen> Widget for PseudoTerminal<'_, S> {
+impl<S: Screen> Widget for &PseudoTerminal<'_, S> {
     #[inline]
     fn render(self, area: Rect, buf: &mut Buffer) {
         Clear.render(area, buf);
@@ -294,7 +294,14 @@ impl<S: Screen> Widget for PseudoTerminal<'_, S> {
             b.clone().render(area, buf);
             inner_area
         });
-        state::handle(&self, area, buf);
+        state::handle(self, area, buf);
+    }
+}
+
+impl<S: Screen> Widget for PseudoTerminal<'_, S> {
+    #[inline]
+    fn render(self, area: Rect, buf: &mut Buffer) {
+        (&self).render(area, buf);
     }
 }
 


### PR DESCRIPTION
Allow rendering `PseudoTerminal` by reference, so consumers can
call frame.render_widget(&pseudo_term, area) without consuming
the widget. This follows the ratatui: `0.30` recommendation of implementing
Widget for &T rather than implementing `WidgetRef` directly.

The consuming impl now delegates to the reference impl.

This is potentially a breaking change for people that implemented
and relied on type inference for `&PseudoTerminal` without implementing
`Widget` itself.

Closes: #194
