### PR TITLE
vt100_imp: set fg/bg on Style before applying cell

### DIFF
--- a/src/vt100_imp.rs
+++ b/src/vt100_imp.rs
@@ -58,9 +58,7 @@ fn fill_buf_cell(screen_cell: &vt100::Cell, buf_cell: &mut ratatui_core::buffer:
     if screen_cell.dim() {
         style = style.add_modifier(Modifier::DIM);
     }
-    buf_cell.set_style(style);
-    buf_cell.set_fg(fg.into());
-    buf_cell.set_bg(bg.into());
+    buf_cell.set_style(style.fg(fg.into()).bg(bg.into()));
 }
 
 /// Represents a foreground or background color for cells.


### PR DESCRIPTION
Set colors on Style directly so a single set_style() call
applies everything, eliminating two redundant method calls per cell.
