### PR TITLE
vt100: simplify color mapping

### DIFF
--- a/src/vt100_imp.rs
+++ b/src/vt100_imp.rs
@@ -37,93 +37,39 @@ impl Cell for vt100::Cell {
 
 #[inline]
 fn fill_buf_cell(screen_cell: &vt100::Cell, buf_cell: &mut ratatui_core::buffer::Cell) {
-    let fg = screen_cell.fgcolor();
-    let bg = screen_cell.bgcolor();
     if screen_cell.has_contents() {
         buf_cell.set_symbol(screen_cell.contents());
     }
-    let fg: Color = fg.into();
-    let bg: Color = bg.into();
-    let mut style = Style::reset();
+
+    let mut modifier = Modifier::empty();
     if screen_cell.bold() {
-        style = style.add_modifier(Modifier::BOLD);
+        modifier |= Modifier::BOLD;
     }
     if screen_cell.italic() {
-        style = style.add_modifier(Modifier::ITALIC);
+        modifier |= Modifier::ITALIC;
     }
     if screen_cell.underline() {
-        style = style.add_modifier(Modifier::UNDERLINED);
+        modifier |= Modifier::UNDERLINED;
     }
     if screen_cell.inverse() {
-        style = style.add_modifier(Modifier::REVERSED);
+        modifier |= Modifier::REVERSED;
     }
     if screen_cell.dim() {
-        style = style.add_modifier(Modifier::DIM);
+        modifier |= Modifier::DIM;
     }
-    buf_cell.set_style(style.fg(fg.into()).bg(bg.into()));
+
+    let fg = map_color(screen_cell.fgcolor());
+    let bg = map_color(screen_cell.bgcolor());
+
+    buf_cell.set_style(Style::reset().fg(fg).bg(bg).add_modifier(modifier));
 }
 
-/// Represents a foreground or background color for cells.
-/// Intermediate translation layer between
-/// [`vt100::Screen`] and [`ratatui_core::style::Color`]
-#[allow(dead_code)]
-enum Color {
-    Reset,
-    Black,
-    Red,
-    Green,
-    Yellow,
-    Blue,
-    Magenta,
-    Cyan,
-    Gray,
-    DarkGray,
-    LightRed,
-    LightGreen,
-    LightYellow,
-    LightBlue,
-    LightMagenta,
-    LightCyan,
-    White,
-    Rgb(u8, u8, u8),
-    Indexed(u8),
-}
-
-impl From<vt100::Color> for Color {
-    #[inline]
-    fn from(value: vt100::Color) -> Self {
-        match value {
-            vt100::Color::Default => Self::Reset,
-            vt100::Color::Idx(i) => Self::Indexed(i),
-            vt100::Color::Rgb(r, g, b) => Self::Rgb(r, g, b),
-        }
-    }
-}
-
-impl From<Color> for vt100::Color {
-    #[inline]
-    fn from(value: Color) -> Self {
-        match value {
-            Color::Reset => Self::Default,
-            Color::Black => Self::Idx(0),
-            Color::Red => Self::Idx(1),
-            Color::Green => Self::Idx(2),
-            Color::Yellow => Self::Idx(3),
-            Color::Blue => Self::Idx(4),
-            Color::Magenta => Self::Idx(5),
-            Color::Cyan => Self::Idx(6),
-            Color::Gray => Self::Idx(7),
-            Color::DarkGray => Self::Idx(8),
-            Color::LightRed => Self::Idx(9),
-            Color::LightGreen => Self::Idx(10),
-            Color::LightYellow => Self::Idx(11),
-            Color::LightBlue => Self::Idx(12),
-            Color::LightMagenta => Self::Idx(13),
-            Color::LightCyan => Self::Idx(14),
-            Color::White => Self::Idx(15),
-            Color::Rgb(r, g, b) => Self::Rgb(r, g, b),
-            Color::Indexed(i) => Self::Idx(i),
-        }
+#[inline]
+fn map_color(color: vt100::Color) -> ratatui_core::style::Color {
+    match color {
+        vt100::Color::Default => ratatui_core::style::Color::Reset,
+        vt100::Color::Idx(i) => ratatui_core::style::Color::Indexed(i),
+        vt100::Color::Rgb(r, g, b) => ratatui_core::style::Color::Rgb(r, g, b),
     }
 }
 
@@ -173,32 +119,5 @@ mod tests {
             visible_row >= 4,
             "cursor at visible row {visible_row} should be off-screen (>= 4 rows)"
         );
-    }
-}
-
-impl From<Color> for ratatui_core::style::Color {
-    #[inline]
-    fn from(value: Color) -> Self {
-        match value {
-            Color::Reset => Self::Reset,
-            Color::Black => Self::Black,
-            Color::Red => Self::Red,
-            Color::Green => Self::Green,
-            Color::Yellow => Self::Yellow,
-            Color::Blue => Self::Blue,
-            Color::Magenta => Self::Magenta,
-            Color::Cyan => Self::Cyan,
-            Color::Gray => Self::Gray,
-            Color::DarkGray => Self::DarkGray,
-            Color::LightRed => Self::LightRed,
-            Color::LightGreen => Self::LightGreen,
-            Color::LightYellow => Self::LightYellow,
-            Color::LightBlue => Self::LightBlue,
-            Color::LightMagenta => Self::LightMagenta,
-            Color::LightCyan => Self::LightCyan,
-            Color::White => Self::White,
-            Color::Rgb(r, g, b) => Self::Rgb(r, g, b),
-            Color::Indexed(i) => Self::Indexed(i),
-        }
     }
 }


### PR DESCRIPTION
Remove the intermediate Color enum.
`ratatui` itself can now map all the Colors, so we don't need the enum
anymore.

Also optimize style mapping slightly through building modifiers up
incrementally.
